### PR TITLE
fix(booking): forward structured customer + pre-order data instead of a notes blob

### DIFF
--- a/app/api/table-bookings/route.ts
+++ b/app/api/table-bookings/route.ts
@@ -16,6 +16,11 @@ const API_KEY = process.env.ANCHOR_API_KEY
 
 type BookingPurpose = 'food' | 'drinks'
 
+type SundayPreorderItem = {
+  menu_dish_id: string
+  quantity: number
+}
+
 type ManagementTableBookingPayload = {
   phone: string
   first_name?: string
@@ -27,6 +32,9 @@ type ManagementTableBookingPayload = {
   purpose: BookingPurpose
   notes?: string
   sunday_lunch?: boolean
+  dietary_requirements?: string[]
+  allergies?: string[]
+  sunday_preorder_items?: SundayPreorderItem[]
   default_country_code?: string
 }
 
@@ -49,6 +57,7 @@ type LegacyTableBookingPayload = {
   celebration_type?: string
   notes?: string
   menu_selections?: Array<{
+    menu_dish_id?: string
     guest_name?: string
     custom_item_name?: string
     item_type?: string
@@ -64,34 +73,6 @@ function mergeNotes(...parts: Array<string | undefined>): string | undefined {
 
   if (merged.length === 0) return undefined
   return merged.join('\n')
-}
-
-function buildNameLine(firstName?: string, lastName?: string): string | undefined {
-  const fullName = [asTrimmedString(firstName), asTrimmedString(lastName)]
-    .filter(Boolean)
-    .join(' ')
-
-  if (!fullName) return undefined
-  return `Name: ${fullName}`
-}
-
-function buildMenuSelectionNotes(value: unknown): string | undefined {
-  if (!Array.isArray(value) || value.length === 0) return undefined
-
-  const parts = value
-    .map((entry) => {
-      if (!entry || typeof entry !== 'object') return null
-      const item = entry as Record<string, unknown>
-      const guest = asTrimmedString(item.guest_name) || 'Guest'
-      const dish = asTrimmedString(item.custom_item_name) || asTrimmedString(item.item_name)
-      const quantity = asPositiveInt(item.quantity) || 1
-      if (!dish) return null
-      return `${guest}: ${dish} x${quantity}`
-    })
-    .filter((line): line is string => Boolean(line))
-
-  if (parts.length === 0) return undefined
-  return `Sunday lunch pre-order: ${parts.join(' | ')}`
 }
 
 function createIdempotencyKey(prefix: string): string {
@@ -133,56 +114,61 @@ function toStringList(value: unknown): string[] {
   return single ? [single] : []
 }
 
-function buildLegacyNotes(payload: LegacyTableBookingPayload): string | undefined {
-  const lines: string[] = []
+// Aggregates menu_selections entries into sunday_preorder_items keyed by
+// menu_dish_id. Entries without a menu_dish_id are skipped -- they'll still
+// appear in the auto-generated note blob as a kitchen-side fallback, but the
+// management API now expects structured UUIDs so it can populate
+// table_booking_items.
+function buildSundayPreorderItems(
+  value: unknown
+): SundayPreorderItem[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined
 
-  const firstName = asTrimmedString(payload.customer?.first_name)
-  const lastName = asTrimmedString(payload.customer?.last_name)
-  const fullName = [firstName, lastName].filter(Boolean).join(' ')
-  if (fullName) lines.push(`Name: ${fullName}`)
+  const totals = new Map<string, number>()
 
-  const email = asTrimmedString(payload.customer?.email)
-  if (email) lines.push(`Email: ${email}`)
-
-  const occasion = asTrimmedString(payload.celebration_type)
-  if (occasion) lines.push(`Occasion: ${occasion}`)
-
-  const specialRequirements = asTrimmedString(payload.special_requirements)
-  if (specialRequirements) lines.push(`Special requirements: ${specialRequirements}`)
-
-  const dietaryRequirements = toStringList(payload.dietary_requirements)
-  if (dietaryRequirements.length > 0) {
-    lines.push(`Dietary requirements: ${dietaryRequirements.join(', ')}`)
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue
+    const item = entry as Record<string, unknown>
+    const menuDishId = asTrimmedString(item.menu_dish_id)
+    if (!menuDishId) continue
+    const quantity = asPositiveInt(item.quantity) ?? 1
+    totals.set(menuDishId, (totals.get(menuDishId) ?? 0) + quantity)
   }
 
-  const allergies = toStringList(payload.allergies)
-  if (allergies.length > 0) {
-    lines.push(`Allergies: ${allergies.join(', ')}`)
-  }
+  if (totals.size === 0) return undefined
 
-  if (Array.isArray(payload.menu_selections) && payload.menu_selections.length > 0) {
-    const selectionSummary = payload.menu_selections
-      .slice(0, 12)
-      .map((item) => {
-        const guest = asTrimmedString(item.guest_name) || 'Guest'
-        const dish = asTrimmedString(item.custom_item_name) || 'Menu item'
-        const quantity = asPositiveInt(item.quantity) || 1
-        return `${guest}: ${dish} x${quantity}`
-      })
-      .join(' | ')
-
-    if (selectionSummary) {
-      lines.push(`Sunday lunch pre-order: ${selectionSummary}`)
-    }
-  }
-
-  const explicitNotes = asTrimmedString(payload.notes)
-  if (explicitNotes) lines.push(`Notes: ${explicitNotes}`)
-
-  if (lines.length === 0) return undefined
-  return lines.join('\n')
+  return Array.from(totals, ([menu_dish_id, quantity]) => ({ menu_dish_id, quantity }))
 }
 
+// A human-readable fallback summary of the pre-order in case saveSundayPreorder
+// on the management side fails -- it stays in the free-text notes column so
+// the kitchen is never blind. Once we have confidence in the structured path
+// we can drop this.
+function buildMenuSelectionFallbackNote(
+  value: LegacyTableBookingPayload['menu_selections']
+): string | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined
+
+  const parts = value
+    .slice(0, 12)
+    .map((item) => {
+      const guest = asTrimmedString(item.guest_name) || 'Guest'
+      const dish = asTrimmedString(item.custom_item_name) || 'Menu item'
+      const quantity = asPositiveInt(item.quantity) || 1
+      return `${guest}: ${dish} x${quantity}`
+    })
+    .join(' | ')
+
+  if (!parts) return undefined
+  return `Sunday lunch pre-order: ${parts}`
+}
+
+// Parses either of the two shapes the site currently sends -- the "management"
+// top-level shape (ManagementTableBookingForm) and the "legacy" nested
+// shape with a customer{} wrapper (SundayLunchBookingForm) -- into the single
+// structured payload the management API expects. Key guarantee: customer name,
+// email, dietary needs, allergies, and per-guest pre-order dishes end up in
+// their own structured fields, not stuffed into the notes blob.
 function normaliseIncomingPayload(input: unknown): {
   payload?: ManagementTableBookingPayload
   error?: string
@@ -193,68 +179,85 @@ function normaliseIncomingPayload(input: unknown): {
 
   const body = input as Record<string, unknown>
 
-  const isNewShape =
-    typeof body.phone === 'string' ||
-    typeof body.purpose === 'string' ||
-    typeof body.sunday_lunch === 'boolean'
+  // Top-level first_name/last_name/email/phone (management form) takes
+  // precedence; fall back to the nested customer{} object for the Sunday lunch
+  // form. Either is accepted.
+  const customer = (body.customer && typeof body.customer === 'object'
+    ? (body.customer as Record<string, unknown>)
+    : {}) as Record<string, unknown>
 
-  if (isNewShape) {
-    const phone = asTrimmedString(body.phone)
-    const date = asTrimmedString(body.date)
-    const time = asTrimmedString(body.time)
-    const partySize = asPositiveInt(body.party_size)
-    const purpose = body.purpose === 'drinks' ? 'drinks' : body.purpose === 'food' ? 'food' : undefined
-    const firstName = asTrimmedString(body.first_name)
-    const lastName = asTrimmedString(body.last_name)
-    const menuSelectionNotes = buildMenuSelectionNotes(body.menu_selections)
-    const notes = mergeNotes(buildNameLine(firstName, lastName), menuSelectionNotes, asTrimmedString(body.notes))
-    const sundayLunch = body.sunday_lunch === true
-    const defaultCountryCode = asTrimmedString(body.default_country_code)
+  const phone =
+    asTrimmedString(body.phone) ||
+    asTrimmedString(customer.mobile_number) ||
+    asTrimmedString(body.customer_phone)
 
-    if (!phone || !date || !time || !partySize || !purpose) {
-      return { error: 'Missing required fields: phone, date, time, party_size, purpose' }
-    }
+  const firstName = asTrimmedString(body.first_name) || asTrimmedString(customer.first_name)
+  const lastName = asTrimmedString(body.last_name) || asTrimmedString(customer.last_name)
+  const email = asTrimmedString(body.email) || asTrimmedString(customer.email)
 
-    return {
-      payload: {
-        phone,
-        ...(firstName ? { first_name: firstName } : {}),
-        ...(lastName ? { last_name: lastName } : {}),
-        ...(asTrimmedString(body.email) ? { email: asTrimmedString(body.email) } : {}),
-        date,
-        time,
-        party_size: partySize,
-        purpose,
-        ...(notes ? { notes } : {}),
-        ...(sundayLunch ? { sunday_lunch: true } : {}),
-        ...(defaultCountryCode ? { default_country_code: defaultCountryCode } : {})
-      }
-    }
+  const date = asTrimmedString(body.date)
+  const time = asTrimmedString(body.time)
+  const partySize = asPositiveInt(body.party_size)
+  const defaultCountryCode = asTrimmedString(body.default_country_code)
+
+  // Sunday lunch is signalled either by a top-level boolean or by the legacy
+  // booking_type string. Either works.
+  const sundayLunch =
+    body.sunday_lunch === true || body.booking_type === 'sunday_lunch'
+
+  // Sunday lunch always implies a food booking; otherwise respect purpose or
+  // default to food (kitchen bookings are the common case via this route).
+  const explicitPurpose =
+    body.purpose === 'drinks' ? 'drinks' : body.purpose === 'food' ? 'food' : undefined
+  const purpose: BookingPurpose = sundayLunch
+    ? 'food'
+    : explicitPurpose ?? (body.purpose === undefined ? 'food' : undefined as unknown as BookingPurpose)
+
+  if (!phone || !date || !time || !partySize || !purpose) {
+    return { error: 'Missing required fields: phone, date, time, party_size, purpose' }
   }
 
-  const legacy = body as LegacyTableBookingPayload
-  const phone = asTrimmedString(legacy.customer?.mobile_number) || asTrimmedString(legacy.customer_phone)
-  const date = asTrimmedString(legacy.date)
-  const time = asTrimmedString(legacy.time)
-  const partySize = asPositiveInt(legacy.party_size)
-  const purpose = legacy.purpose === 'drinks' ? 'drinks' : 'food'
-  const sundayLunch = legacy.booking_type === 'sunday_lunch'
-  const notes = buildLegacyNotes(legacy)
+  const dietaryRequirements = toStringList(body.dietary_requirements)
+  const allergies = toStringList(body.allergies)
 
-  if (!phone || !date || !time || !partySize) {
-    return { error: 'Missing required fields: phone, date, time, and party_size' }
-  }
+  const sundayPreorderItems = buildSundayPreorderItems(body.menu_selections)
+
+  // notes is strictly the user's free-text (e.g. "anniversary dinner") -- the
+  // Sunday lunch form labels it "special_requirements", the management form
+  // labels it "notes". We also append a human-readable fallback summary of the
+  // pre-order so the kitchen isn't blind if the structured items save fails on
+  // the management side.
+  const userNote =
+    asTrimmedString(body.special_requirements) || asTrimmedString(body.notes)
+  const occasionNote = asTrimmedString(body.celebration_type)
+  const fallbackSelectionNote = sundayLunch
+    ? buildMenuSelectionFallbackNote(
+        body.menu_selections as LegacyTableBookingPayload['menu_selections']
+      )
+    : undefined
+  const notes = mergeNotes(
+    occasionNote ? `Occasion: ${occasionNote}` : undefined,
+    userNote,
+    fallbackSelectionNote
+  )
 
   return {
     payload: {
       phone,
+      ...(firstName ? { first_name: firstName } : {}),
+      ...(lastName ? { last_name: lastName } : {}),
+      ...(email ? { email } : {}),
       date,
       time,
       party_size: partySize,
       purpose,
       ...(notes ? { notes } : {}),
-      ...(sundayLunch ? { sunday_lunch: true } : {})
-    }
+      ...(sundayLunch ? { sunday_lunch: true } : {}),
+      ...(dietaryRequirements.length > 0 ? { dietary_requirements: dietaryRequirements } : {}),
+      ...(allergies.length > 0 ? { allergies } : {}),
+      ...(sundayPreorderItems ? { sunday_preorder_items: sundayPreorderItems } : {}),
+      ...(defaultCountryCode ? { default_country_code: defaultCountryCode } : {}),
+    },
   }
 }
 

--- a/components/features/TableBooking/ManagementTableBookingForm.tsx
+++ b/components/features/TableBooking/ManagementTableBookingForm.tsx
@@ -1302,6 +1302,7 @@ export function ManagementTableBookingForm({ prefill }: ManagementTableBookingFo
   function buildSundayMenuSelections(): {
     ok: boolean
     selections?: Array<{
+      menu_dish_id: string
       guest_name: string
       custom_item_name: string
       item_type: 'main'
@@ -1340,6 +1341,7 @@ export function ManagementTableBookingForm({ prefill }: ManagementTableBookingFo
     const selections = guestOrders.map((order, index) => {
       const item = getMenuItem(order.menuItemId)
       return {
+        menu_dish_id: order.menuItemId,
         guest_name: order.guestName.trim() || `Guest ${index + 1}`,
         custom_item_name: item?.name || 'Sunday lunch main',
         item_type: 'main' as const,

--- a/components/features/TableBooking/SundayLunchBookingForm.tsx
+++ b/components/features/TableBooking/SundayLunchBookingForm.tsx
@@ -417,6 +417,7 @@ export default function SundayLunchBookingForm({ className }: SundayLunchBooking
       
       // Convert menu selections to the required API format
       const menuItems: Array<{
+        menu_dish_id: string
         custom_item_name: string
         item_type: string
         quantity: number
@@ -430,18 +431,20 @@ export default function SundayLunchBookingForm({ className }: SundayLunchBooking
           const mainItem = menu.mains.find(m => m.id === selection.menu_item_id)
           if (mainItem) {
             menuItems.push({
+              menu_dish_id: mainItem.id,
               custom_item_name: mainItem.name,
               item_type: 'main',
               quantity: 1,
               guest_name: selection.guest_name,
               price_at_booking: mainItem.price
             })
-            
+
             // Add included sides for each guest
             menu.sides
               .filter(side => side.included)
               .forEach(side => {
                 menuItems.push({
+                  menu_dish_id: side.id,
                   custom_item_name: side.name,
                   item_type: 'side',
                   quantity: 1,
@@ -452,7 +455,7 @@ export default function SundayLunchBookingForm({ className }: SundayLunchBooking
           }
         }
       })
-      
+
       // Add optional extras
       sideSelections
         .filter(side => side.quantity > 0)
@@ -462,6 +465,7 @@ export default function SundayLunchBookingForm({ className }: SundayLunchBooking
             // Add one entry per quantity
             for (let i = 0; i < sideSelection.quantity; i++) {
               menuItems.push({
+                menu_dish_id: sideItem.id,
                 custom_item_name: sideItem.name,
                 item_type: 'side',
                 quantity: 1,

--- a/tests/api/tableBookingsProxyStructuredForward.test.ts
+++ b/tests/api/tableBookingsProxyStructuredForward.test.ts
@@ -1,0 +1,246 @@
+/**
+ * A1 regression: verify the website's /api/table-bookings proxy:
+ *   1. Forwards customer name + email as top-level structured fields
+ *      (not buried in a notes blob) for BOTH form shapes.
+ *   2. Forwards dietary_requirements and allergies as arrays.
+ *   3. Transforms menu_selections into aggregated sunday_preorder_items keyed
+ *      by menu_dish_id.
+ *   4. Leaves `notes` as just the user's free-text (plus a kitchen-side
+ *      fallback summary so the kitchen isn't blind if the structured path
+ *      fails downstream).
+ */
+
+jest.mock('@/lib/management-api-base', () => ({
+  getManagementApiBaseUrl: () => 'https://example.invalid/api',
+}))
+
+jest.mock('@/lib/api', () => ({
+  anchorAPI: {
+    getBusinessHours: jest.fn().mockResolvedValue({}),
+  },
+}))
+
+jest.mock('@/lib/table-booking-service-windows', () => ({
+  resolveServiceRanges: () => ({ closed: false, ranges: [{ start: '12:00', end: '17:00' }] }),
+  isTimeWithinRanges: () => true,
+  normalizeTime: (t: string) => (t.length === 5 ? `${t}:00` : t),
+}))
+
+jest.mock('@/lib/spam-protection', () => ({
+  checkSpamProtection: jest.fn().mockResolvedValue({ blocked: false }),
+}))
+
+jest.mock('@/lib/sunday-lunch-cutoff', () => ({
+  getSundayLunchCutoffDate: () => '2099-01-01',
+  hasSundayLunchCutoffPassed: () => false,
+  isSundayIsoDate: () => true,
+}))
+
+jest.mock('@/lib/upstream-json', () => ({
+  getSafeUpstreamErrorMessage: () => 'upstream error',
+  safeJsonParse: (t: string) => {
+    try {
+      return JSON.parse(t)
+    } catch {
+      return null
+    }
+  },
+}))
+
+jest.mock('@/lib/error-handling', () => ({
+  createApiErrorResponse: (message: string, status: number) =>
+    new Response(JSON.stringify({ success: false, error: message }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  logError: jest.fn(),
+}))
+
+const originalEnv = process.env
+
+beforeAll(() => {
+  process.env = { ...originalEnv, ANCHOR_API_KEY: 'test-key' }
+})
+
+afterAll(() => {
+  process.env = originalEnv
+})
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/table-bookings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function getPostHandler() {
+  const mod = await import('@/app/api/table-bookings/route')
+  return mod.POST
+}
+
+function installUpstreamFetch() {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  ;(global as any).fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    calls.push({ url, init: init ?? {} })
+    return new Response(
+      JSON.stringify({ success: true, data: { state: 'pending_payment' } }),
+      { status: 201, headers: { 'content-type': 'application/json' } },
+    )
+  })
+  return calls
+}
+
+describe('website /api/table-bookings proxy — structured field forwarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('forwards structured fields from the legacy SundayLunchBookingForm shape (nested customer{})', async () => {
+    const calls = installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const body = {
+      booking_type: 'sunday_lunch',
+      date: '2026-04-26',
+      time: '13:00',
+      party_size: 2,
+      customer: {
+        first_name: 'Alice',
+        last_name: 'Smith',
+        email: 'alice@example.com',
+        mobile_number: '+447000000000',
+      },
+      special_requirements: 'Anniversary',
+      dietary_requirements: ['vegetarian'],
+      allergies: ['nuts'],
+      menu_selections: [
+        {
+          menu_dish_id: '11111111-1111-4111-8111-111111111111',
+          custom_item_name: 'Roasted Chicken',
+          item_type: 'main',
+          quantity: 1,
+          guest_name: 'Guest 1',
+          price_at_booking: 19,
+        },
+        {
+          menu_dish_id: '11111111-1111-4111-8111-111111111111',
+          custom_item_name: 'Roasted Chicken',
+          item_type: 'main',
+          quantity: 1,
+          guest_name: 'Guest 2',
+          price_at_booking: 19,
+        },
+        {
+          menu_dish_id: '22222222-2222-4222-8222-222222222222',
+          custom_item_name: 'Cauliflower Cheese',
+          item_type: 'side',
+          quantity: 2,
+          guest_name: 'Table',
+          price_at_booking: 4,
+        },
+      ],
+      source: 'website',
+    }
+
+    const res = await POST(buildRequest(body) as any)
+    expect(res.status).toBe(201)
+
+    expect(calls).toHaveLength(1)
+    const forwarded = JSON.parse(String(calls[0].init.body))
+
+    expect(forwarded.phone).toBe('+447000000000')
+    expect(forwarded.first_name).toBe('Alice')
+    expect(forwarded.last_name).toBe('Smith')
+    expect(forwarded.email).toBe('alice@example.com')
+    expect(forwarded.sunday_lunch).toBe(true)
+    expect(forwarded.purpose).toBe('food')
+    expect(forwarded.dietary_requirements).toEqual(['vegetarian'])
+    expect(forwarded.allergies).toEqual(['nuts'])
+
+    // Pre-order items aggregated by menu_dish_id
+    expect(forwarded.sunday_preorder_items).toEqual(
+      expect.arrayContaining([
+        { menu_dish_id: '11111111-1111-4111-8111-111111111111', quantity: 2 },
+        { menu_dish_id: '22222222-2222-4222-8222-222222222222', quantity: 2 },
+      ]),
+    )
+
+    // Notes holds the user's typed text, not a big blob
+    expect(forwarded.notes).toContain('Anniversary')
+    expect(forwarded.notes).not.toContain('Name:')
+    expect(forwarded.notes).not.toContain('Email:')
+    expect(forwarded.notes).not.toContain('Dietary requirements:')
+  })
+
+  it('forwards structured fields from the management form shape (top-level fields)', async () => {
+    const calls = installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const body = {
+      phone: '+447000000000',
+      first_name: 'Bob',
+      last_name: 'Jones',
+      email: 'bob@example.com',
+      date: '2026-04-26',
+      time: '13:00',
+      party_size: 3,
+      purpose: 'food',
+      sunday_lunch: true,
+      notes: 'High chair please',
+      menu_selections: [
+        {
+          menu_dish_id: '33333333-3333-4333-8333-333333333333',
+          custom_item_name: 'Pork Belly',
+          item_type: 'main',
+          quantity: 1,
+          guest_name: 'Guest 1',
+          price_at_booking: 19,
+        },
+      ],
+    }
+
+    const res = await POST(buildRequest(body) as any)
+    expect(res.status).toBe(201)
+
+    const forwarded = JSON.parse(String(calls[0].init.body))
+    expect(forwarded.first_name).toBe('Bob')
+    expect(forwarded.last_name).toBe('Jones')
+    expect(forwarded.email).toBe('bob@example.com')
+    expect(forwarded.sunday_preorder_items).toEqual([
+      { menu_dish_id: '33333333-3333-4333-8333-333333333333', quantity: 1 },
+    ])
+    expect(forwarded.notes).toContain('High chair please')
+  })
+
+  it('omits sunday_preorder_items when menu_selections have no menu_dish_id', async () => {
+    const calls = installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const body = {
+      booking_type: 'sunday_lunch',
+      date: '2026-04-26',
+      time: '13:00',
+      party_size: 2,
+      customer: { mobile_number: '+447000000000' },
+      menu_selections: [
+        {
+          custom_item_name: 'Roasted Chicken',
+          item_type: 'main',
+          quantity: 1,
+          guest_name: 'Guest 1',
+          price_at_booking: 19,
+        },
+      ],
+    }
+
+    const res = await POST(buildRequest(body) as any)
+    expect(res.status).toBe(201)
+
+    const forwarded = JSON.parse(String(calls[0].init.body))
+    expect(forwarded.sunday_preorder_items).toBeUndefined()
+    // Still a kitchen-side fallback in notes so service isn't blind
+    expect(forwarded.notes ?? '').toContain('Roasted Chicken')
+  })
+})


### PR DESCRIPTION
## What changed
Rewrites the `/api/table-bookings` proxy so it forwards customer name/email, dietary requirements, allergies, and per-guest pre-order dishes as structured fields instead of flattening them into a single `notes` text blob. Both booking form shapes (nested `customer{}` and top-level) now work through a single code path.

The two booking forms (`SundayLunchBookingForm` and `ManagementTableBookingForm`) now include `menu_dish_id` in each `menu_selections` entry, giving the proxy a UUID to aggregate on when building the `sunday_preorder_items` array it forwards to the management API.

## Why
The old legacy-shape branch dropped `first_name`, `last_name`, and `email` entirely, then `buildLegacyNotes` stuffed everything else into one free-text blob. Consequences on the management side:
- The admin pre-order tab was always empty for website-sourced bookings
- The kitchen prep PDF was useless for those bookings
- First-time customers ended up with a phone number only — no name, no email — in the `customers` table
- Dietary requirements and allergies sat buried in text instead of the dedicated array columns

Root cause documented in [docs/superpowers/specs/2026-04-18-sunday-lunch-booking-pipeline-fix-design.md](https://github.com/peterjpitcher/the-anchor-management-tools/blob/main/docs/superpowers/specs/2026-04-18-sunday-lunch-booking-pipeline-fix-design.md) Problem A.

Companion to management-API [#72](https://github.com/peterjpitcher/the-anchor-management-tools/pull/72), which accepts the new fields and wires items into `table_booking_items` via `saveSundayPreorderByBookingId`.

## Testing done
- [x] Jest: 3 new regression tests pass (legacy shape, new shape, preorder-item aggregation, fallback note behaviour).
- [x] Typecheck: zero new errors. 15 pre-existing errors on main are unchanged (test-file variable redeclarations + `ManagementTableBookingForm.test.tsx` type inference on `submittedPayload`).
- [x] Full Jest sweep: same pass/fail counts as main (20 failed / 10 passed in legacy test files — all pre-existing, none regressed).
- [x] Production build clean.

## Complexity score
M — three files changed (one proxy + two forms) + one new test file. One logical concern.

## Breaking changes
None for customers. The proxy still accepts both form shapes. The only outbound change is new structured fields added to the management API request — the management API ignores unknown fields when they aren't yet supported. Management PR #72 adds the fields and must be deployed first for end-to-end benefit; website PR still works on its own (it just sends extra fields the backend silently strips).

## Migration risk
None — no schema changes, no environment-variable changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)