### PR TITLE
feat: collect a name per ticket on paid event bookings

### DIFF
--- a/app/api/event-bookings/__tests__/route.test.ts
+++ b/app/api/event-bookings/__tests__/route.test.ts
@@ -177,5 +177,12 @@ describe('website /api/event-bookings proxy, per-ticket attendee names', () => {
     expect(res.status).toBe(201)
     const forwarded = JSON.parse(String(calls[0].init.body))
     expect(forwarded.attendee_names).toBeUndefined()
+    const expectedLegacyKey = `evt_${Buffer.from(JSON.stringify({
+      event_id: VALID_BASE.event_id,
+      phone: VALID_BASE.phone,
+      seats: VALID_BASE.seats,
+      communication_consent: ''
+    })).toString('base64url').slice(0, 120)}`
+    expect((calls[0].init.headers as Record<string, string>)['Idempotency-Key']).toBe(expectedLegacyKey)
   })
 })

--- a/app/api/event-bookings/__tests__/route.test.ts
+++ b/app/api/event-bookings/__tests__/route.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Per-ticket attendee-name behaviour for the website /api/event-bookings proxy.
+ *
+ * - Paid events (event_price > 0) require a name for every ticket and forward
+ *   the `attendee_names` array to the management API.
+ * - Free events do not require names and forward none.
+ * - A name count that does not match `seats`, or any blank name, is rejected 400.
+ */
+
+export {}
+
+jest.mock('@/lib/management-api-base', () => ({
+  getManagementApiBaseUrl: () => 'https://example.invalid/api'
+}))
+
+jest.mock('@/lib/spam-protection', () => ({
+  checkSpamProtection: jest.fn().mockResolvedValue({ blocked: false })
+}))
+
+jest.mock('@/lib/upstream-json', () => ({
+  getSafeUpstreamErrorMessage: () => 'upstream error',
+  safeJsonParse: (text: string) => {
+    try {
+      return JSON.parse(text)
+    } catch {
+      return null
+    }
+  }
+}))
+
+jest.mock('@/lib/error-handling', () => ({
+  createApiErrorResponse: (message: string, status: number) =>
+    new Response(JSON.stringify({ success: false, error: message }), {
+      status,
+      headers: { 'content-type': 'application/json' }
+    }),
+  logError: jest.fn()
+}))
+
+jest.mock('@/lib/booking-conversion-forwarding', () => ({
+  forwardBookingConversionToCheersAI: jest.fn().mockResolvedValue(undefined)
+}))
+
+jest.mock('@/lib/communication-consent-server', () => ({
+  sanitizeCommunicationConsent: () => undefined,
+  communicationConsentIdempotencyPart: () => ''
+}))
+
+const VALID_BASE = {
+  event_id: 'evt-12345678',
+  phone: '07700900000',
+  first_name: 'Alice',
+  last_name: 'Booker',
+  seats: 2
+}
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/event-bookings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}
+
+async function getPostHandler() {
+  const mod = await import('@/app/api/event-bookings/route')
+  return mod.POST
+}
+
+function installUpstreamFetch() {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  ;(global as any).fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    calls.push({ url, init: init ?? {} })
+    return new Response(
+      JSON.stringify({ success: true, data: { state: 'confirmed', booking_id: 'bk-1' } }),
+      { status: 201, headers: { 'content-type': 'application/json' } }
+    )
+  })
+  return calls
+}
+
+const ORIGINAL_ENV = process.env
+
+beforeAll(() => {
+  process.env = { ...ORIGINAL_ENV, ANCHOR_API_KEY: 'test-key' }
+  // jsdom's Response lacks the static json() helper that NextResponse.json delegates to.
+  const ResponseCtor = global.Response as unknown as {
+    json?: (data: unknown, init?: ResponseInit) => Response
+  }
+  if (typeof ResponseCtor.json !== 'function') {
+    ResponseCtor.json = (data: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(data), {
+        ...init,
+        headers: { 'content-type': 'application/json', ...(init?.headers as Record<string, string> | undefined) }
+      })
+  }
+})
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV
+})
+
+beforeEach(() => {
+  process.env.ANCHOR_API_KEY = 'test-key'
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('website /api/event-bookings proxy, per-ticket attendee names', () => {
+  it('rejects a paid booking that is missing attendee names', async () => {
+    installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const res = await POST(buildRequest({ ...VALID_BASE, event_price: 5 }) as any)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('forwards attendee_names for a paid booking with a name per ticket', async () => {
+    const calls = installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const res = await POST(
+      buildRequest({
+        ...VALID_BASE,
+        event_price: 5,
+        attendee_names: ['Alice Booker', 'Bob Guest']
+      }) as any
+    )
+
+    expect(res.status).toBe(201)
+    expect(calls).toHaveLength(1)
+    const forwarded = JSON.parse(String(calls[0].init.body))
+    expect(forwarded.attendee_names).toEqual(['Alice Booker', 'Bob Guest'])
+  })
+
+  it('rejects when the attendee name count does not match seats', async () => {
+    installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const res = await POST(
+      buildRequest({
+        ...VALID_BASE,
+        seats: 3,
+        event_price: 5,
+        attendee_names: ['Alice Booker', 'Bob Guest']
+      }) as any
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects when any attendee name is blank', async () => {
+    installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const res = await POST(
+      buildRequest({
+        ...VALID_BASE,
+        event_price: 5,
+        attendee_names: ['Alice Booker', '   ']
+      }) as any
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  it('does not require names for a free event and forwards none', async () => {
+    const calls = installUpstreamFetch()
+    const POST = await getPostHandler()
+
+    const res = await POST(buildRequest({ ...VALID_BASE }) as any)
+
+    expect(res.status).toBe(201)
+    const forwarded = JSON.parse(String(calls[0].init.body))
+    expect(forwarded.attendee_names).toBeUndefined()
+  })
+})

--- a/app/api/event-bookings/route.ts
+++ b/app/api/event-bookings/route.ts
@@ -17,6 +17,7 @@ type EventBookingPayload = {
   event_id: string
   phone: string
   seats: number
+  attendee_names?: string[]
   first_name?: string
   last_name?: string
   email?: string
@@ -96,6 +97,15 @@ function asSeatingPreference(value: unknown): 'seated' | 'standing' | undefined 
   return normalized === 'seated' || normalized === 'standing' ? normalized : undefined
 }
 
+// Returns a trimmed name array when the input is an array (empties preserved so
+// validatePayload can reject them), or undefined when no array was supplied.
+function asNameArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+}
+
+const MAX_ATTENDEE_NAME_LENGTH = 120
+
 function normalizePayload(input: unknown): { payload?: EventBookingPayload; error?: string } {
   if (!input || typeof input !== 'object') {
     return { error: 'Invalid request body' }
@@ -115,6 +125,7 @@ function normalizePayload(input: unknown): { payload?: EventBookingPayload; erro
   const metaConsentGranted = body.meta_consent_granted === true
   const rawSeatingPreference = body.seating_preference ?? body.seatingPreference
   const seatingPreference = asSeatingPreference(rawSeatingPreference)
+  const attendeeNames = asNameArray(body.attendee_names)
   const communicationConsent = sanitizeCommunicationConsent(body.communication_consent)
 
   if (!eventId || !phone || !seats) {
@@ -136,6 +147,7 @@ function normalizePayload(input: unknown): { payload?: EventBookingPayload; erro
       ...(notes ? { notes } : {}),
       ...(defaultCountryCode ? { default_country_code: defaultCountryCode } : {}),
       ...(seatingPreference ? { seating_preference: seatingPreference } : {}),
+      ...(attendeeNames ? { attendee_names: attendeeNames } : {}),
       ...(metaConsentGranted ? { meta_consent_granted: true } : {}),
       ...copyOptionalStrings(body, [
         'source_url',
@@ -195,6 +207,25 @@ function validatePayload(payload: EventBookingPayload): string | null {
 
   if (payload.notes && payload.notes.length > 500) {
     return 'Notes must be 500 characters or fewer'
+  }
+
+  const attendeeNames = payload.attendee_names
+  const isPaidEvent = typeof payload.event_price === 'number' && payload.event_price > 0
+
+  if (isPaidEvent && (!attendeeNames || attendeeNames.length === 0)) {
+    return 'Please enter a name for each ticket'
+  }
+
+  if (attendeeNames) {
+    if (attendeeNames.some((name) => name.length === 0)) {
+      return 'Please enter a name for each ticket'
+    }
+    if (attendeeNames.some((name) => name.length > MAX_ATTENDEE_NAME_LENGTH)) {
+      return `Each name must be ${MAX_ATTENDEE_NAME_LENGTH} characters or fewer`
+    }
+    if (attendeeNames.length !== payload.seats) {
+      return 'Please enter a name for each ticket'
+    }
   }
 
   return null
@@ -349,6 +380,7 @@ export async function POST(request: NextRequest) {
         event_id: normalized.payload.event_id,
         phone: normalized.payload.phone,
         seats: normalized.payload.seats,
+        attendee_names: normalized.payload.attendee_names ?? null,
         communication_consent: communicationConsentIdempotencyPart(normalized.payload.communication_consent),
       })
 

--- a/app/api/event-bookings/route.ts
+++ b/app/api/event-bookings/route.ts
@@ -380,7 +380,7 @@ export async function POST(request: NextRequest) {
         event_id: normalized.payload.event_id,
         phone: normalized.payload.phone,
         seats: normalized.payload.seats,
-        attendee_names: normalized.payload.attendee_names ?? null,
+        ...(normalized.payload.attendee_names ? { attendee_names: normalized.payload.attendee_names } : {}),
         communication_consent: communicationConsentIdempotencyPart(normalized.payload.communication_consent),
       })
 

--- a/components/features/EventBooking/ManagementEventBookingForm.tsx
+++ b/components/features/EventBooking/ManagementEventBookingForm.tsx
@@ -225,8 +225,11 @@ export function ManagementEventBookingForm({
   const eventUnitPrice = getEventUnitPrice(event)
   const isPaidEvent = typeof eventUnitPrice === 'number' && eventUnitPrice > 0
   const collectsAttendeeNames = isPaidEvent && seats > 1
+  const requiredAdditionalAttendeeCount = Math.max(0, seats - 1)
   const attendeeNamesComplete =
-    !collectsAttendeeNames || additionalAttendeeNames.every((name) => name.trim().length > 0)
+    !collectsAttendeeNames ||
+    (additionalAttendeeNames.length === requiredAdditionalAttendeeCount &&
+      additionalAttendeeNames.every((name) => name.trim().length > 0))
   const seatedRemaining = normalizeRemaining(event.seated_remaining)
   const standingRemaining = normalizeRemaining(event.standing_remaining)
   const totalRemaining = normalizeRemaining(event.total_remaining) ?? normalizeRemaining(event.seats_remaining)

--- a/components/features/EventBooking/ManagementEventBookingForm.tsx
+++ b/components/features/EventBooking/ManagementEventBookingForm.tsx
@@ -198,6 +198,9 @@ export function ManagementEventBookingForm({
   )
   const [seats, setSeats] = useState(2)
   const [seatsDisplay, setSeatsDisplay] = useState('2')
+  // Per-ticket attendee names for tickets 2..N (ticket 1 is the booker above).
+  // Only collected on paid events.
+  const [additionalAttendeeNames, setAdditionalAttendeeNames] = useState<string[]>([])
   const [foodIntent, setFoodIntent] = useState<FoodIntent>('planning_to_eat')
   const [seatingPreference, setSeatingPreference] = useState<EventSeatingPreference>('seated')
   const [submittedSeatingPreference, setSubmittedSeatingPreference] = useState<EventSeatingPreference | null>(null)
@@ -218,6 +221,12 @@ export function ManagementEventBookingForm({
   const selectedFoodIntent = FOOD_INTENT_OPTIONS.find((option) => option.value === foodIntent) || FOOD_INTENT_OPTIONS[0]
   const bookingReassurance = getEventBookingReassurance(event)
   const isCommunalEvent = isCommunalBookingMode(event.booking_mode)
+  // Paid events require a name for every ticket (booker is ticket 1).
+  const eventUnitPrice = getEventUnitPrice(event)
+  const isPaidEvent = typeof eventUnitPrice === 'number' && eventUnitPrice > 0
+  const collectsAttendeeNames = isPaidEvent && seats > 1
+  const attendeeNamesComplete =
+    !collectsAttendeeNames || additionalAttendeeNames.every((name) => name.trim().length > 0)
   const seatedRemaining = normalizeRemaining(event.seated_remaining)
   const standingRemaining = normalizeRemaining(event.standing_remaining)
   const totalRemaining = normalizeRemaining(event.total_remaining) ?? normalizeRemaining(event.seats_remaining)
@@ -250,6 +259,21 @@ export function ManagementEventBookingForm({
       setSeatingPreference('seated')
     }
   }, [isCommunalEvent, seatedDisabled, seatingPreference, standingDisabled])
+
+  // Keep the additional-attendee inputs in step with the seat count (tickets 2..N).
+  useEffect(() => {
+    if (!isPaidEvent) {
+      setAdditionalAttendeeNames((prev) => (prev.length === 0 ? prev : []))
+      return
+    }
+    const needed = Math.max(0, seats - 1)
+    setAdditionalAttendeeNames((prev) => {
+      if (prev.length === needed) return prev
+      const next = prev.slice(0, needed)
+      while (next.length < needed) next.push('')
+      return next
+    })
+  }, [isPaidEvent, seats])
 
   useEffect(() => {
     if (formViewedTracked.current) return
@@ -312,6 +336,22 @@ export function ManagementEventBookingForm({
       return
     }
 
+    // Booker is ticket 1; collect a name for every remaining ticket on paid events.
+    const additionalNamesForSubmit = Array.from(
+      { length: Math.max(0, clampedSeats - 1) },
+      (_, index) => (additionalAttendeeNames[index] ?? '').trim()
+    )
+
+    if (isPaidEvent && additionalNamesForSubmit.some((name) => name.length === 0)) {
+      setLoading(false)
+      setError('Please enter a name for every ticket.')
+      return
+    }
+
+    const attendeeNames = isPaidEvent
+      ? [`${resolvedFirstName} ${resolvedLastName}`.trim(), ...additionalNamesForSubmit]
+      : null
+
     trackEventBookingStart({
       eventId: event.id,
       eventName: event.name,
@@ -350,6 +390,7 @@ export function ManagementEventBookingForm({
           first_name: resolvedFirstName,
           last_name: resolvedLastName,
           seats: clampedSeats,
+          ...(attendeeNames ? { attendee_names: attendeeNames } : {}),
           ...(bookingSeatingPreference ? { seating_preference: bookingSeatingPreference } : {}),
           notes,
           food_intent: foodIntent,
@@ -671,6 +712,33 @@ export function ManagementEventBookingForm({
             />
           </div>
 
+          {collectsAttendeeNames ? (
+            <fieldset className="space-y-2 rounded-sm border border-line bg-surface-sunk p-2.5">
+              <legend className="px-1 text-sm font-semibold text-ink">Who are the tickets for?</legend>
+              <p className="px-1 text-xs leading-relaxed text-ink-muted">
+                Ticket 1 is you. Add a name for each of the other {seats - 1} {seats - 1 === 1 ? 'ticket' : 'tickets'} so we know who to expect.
+              </p>
+              <div className="space-y-2">
+                {additionalAttendeeNames.map((name, index) => (
+                  <Input
+                    key={index}
+                    label={`Ticket ${index + 2} name`}
+                    type="text"
+                    required
+                    value={name}
+                    onChange={(inputEvent) =>
+                      setAdditionalAttendeeNames((prev) =>
+                        prev.map((existing, i) => (i === index ? inputEvent.target.value : existing))
+                      )
+                    }
+                    placeholder="Full name"
+                    autoComplete="off"
+                  />
+                ))}
+              </div>
+            </fieldset>
+          ) : null}
+
           <Input
             label="Mobile number"
             type="tel"
@@ -752,7 +820,7 @@ export function ManagementEventBookingForm({
             fullWidth
             size="lg"
             loading={loading}
-            disabled={TURNSTILE_SITE_KEY ? !turnstileToken : false}
+            disabled={(TURNSTILE_SITE_KEY ? !turnstileToken : false) || !attendeeNamesComplete}
             onClick={() => {
               trackEventBookingFunnelStep({
                 step: 'cta_click',


### PR DESCRIPTION
## What changed
On paid event bookings, the booking form now collects a name for every ticket (booker = ticket 1; the remaining tickets get attendee inputs that track the seat count) and gates submit until they are filled. The names are sent to the management API as an ordered `attendee_names` array. Free-seat events are unchanged.

## Why
Multi-ticket purchases previously captured only the lead booker's name + a seat count, so the venue had no record of who each ticket was for.

## Depends on
the-anchor-management-tools#77 (accepts + stores + displays `attendee_names`). **Merge/deploy that first** — otherwise the names are silently dropped.

## Testing done
- [x] Automated: Jest tests for the `/api/event-bookings` proxy — paid requires names, forwards them, rejects count mismatch / blanks, free events unaffected (5 pass)
- [x] `npm run lint` (0 warnings), `npx tsc --noEmit` clean, `npm run build` success

## Complexity score
S

## Breaking changes
None.

## Migration risk
None (website only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)