### PR TITLE
fix(event-payment): render object-shaped API errors safely

### DIFF
--- a/components/features/EventBooking/PayPalEventPaymentSection.tsx
+++ b/components/features/EventBooking/PayPalEventPaymentSection.tsx
@@ -29,6 +29,19 @@ interface Props {
 
 type PaymentState = 'idle' | 'creating' | 'paying' | 'manual_review' | 'error'
 
+// The management API returns errors as either a plain string or an object
+// envelope `{ code, message }` (e.g. auth/rate-limit paths). Rendering an object
+// into JSX throws "Objects are not valid as a React child", so always resolve to
+// a string before displaying.
+function resolveErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === 'string' && error.trim()) return error
+  if (error && typeof error === 'object') {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === 'string' && message.trim()) return message
+  }
+  return fallback
+}
+
 export function PayPalEventPaymentSection({
   bookingId,
   bookingSummary,
@@ -95,7 +108,7 @@ export function PayPalEventPaymentSection({
         return
       }
 
-      const message = data?.error || 'Payment could not be confirmed. Please try again or call us.'
+      const message = resolveErrorMessage(data?.error, 'Payment could not be confirmed. Please try again or call us.')
       setErrorMessage(message)
       setPaymentState('error')
       onError(message)
@@ -138,7 +151,7 @@ export function PayPalEventPaymentSection({
               })
               const data = await response.json().catch(() => null)
               if (!response.ok || !data?.orderId) {
-                const message = data?.error || 'Could not start PayPal payment.'
+                const message = resolveErrorMessage(data?.error, 'Could not start PayPal payment.')
                 setErrorMessage(message)
                 setPaymentState('error')
                 throw new Error(message)


### PR DESCRIPTION
## What
The PayPal event payment panel did `data?.error || fallback` and rendered the result into JSX. When the management API returns an object-shaped error envelope `{ code, message }` (auth / rate-limit / 5xx paths), React throws *"Objects are not valid as a React child"* and the payment panel crashes mid-checkout.

## Fix
Add `resolveErrorMessage()` to coerce string- **or** object-shaped errors to a display string, applied at both the create-order and capture-order call sites.

## Why it matters
Only fires on failure paths (never the happy path or normal business rejections, which are strings), but when it does the customer loses the whole payment UI instead of seeing a readable message.

## Testing
- [x] `npx tsc --noEmit` clean, `npm run lint` (0 warnings), `npm run build` success

## Deploy
Website is a **manual deploy** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)