### PR TITLE
feat(event-booking): remove food-intent tickbox; clarify attendee names

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -598,7 +598,6 @@ export default async function EventPage({ params }: Props) {
                         event={event}
                         title={bookingFormTitle}
                         compact
-                        foodPrompt={eventBookingCopy.foodPrompt}
                       />
                     )}
                   </div>

--- a/components/features/EventBooking/ManagementEventBookingForm.tsx
+++ b/components/features/EventBooking/ManagementEventBookingForm.tsx
@@ -23,7 +23,6 @@ import {
 const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || ''
 
 type EventBookingState = 'confirmed' | 'pending_payment' | 'full_with_waitlist_option' | 'blocked'
-type FoodIntent = 'planning_to_eat' | 'event_only'
 type EventSeatingPreference = 'seated' | 'standing'
 
 type EventBookingResult = {
@@ -52,7 +51,6 @@ interface ManagementEventBookingFormProps {
     Partial<Pick<Event, 'time' | 'slug' | 'category' | 'price' | 'ticket_price' | 'price_per_seat' | 'online_discount_type' | 'online_discount_value' | 'offers' | 'payment_mode' | 'is_free' | 'seats_remaining' | 'booking_mode' | 'seated_remaining' | 'standing_remaining' | 'total_remaining'>>
   title?: string
   compact?: boolean
-  foodPrompt?: string
 }
 
 const BLOCKED_COPY: Record<string, string> = {
@@ -61,19 +59,6 @@ const BLOCKED_COPY: Record<string, string> = {
   sold_out: 'This event is sold out.',
   payment_required: 'Payment is required to secure this booking.'
 }
-
-const FOOD_INTENT_OPTIONS: Array<{ value: FoodIntent; label: string; description: string }> = [
-  {
-    value: 'planning_to_eat',
-    label: 'Planning to eat before the event',
-    description: 'Arrive early and order from the team on the night.'
-  },
-  {
-    value: 'event_only',
-    label: 'Event or drinks only',
-    description: 'Reserve seats without food on this visit.'
-  }
-]
 
 function getBlockedMessage(reason: string | null | undefined): string {
   if (!reason) return BLOCKED_COPY.blocked
@@ -116,15 +101,6 @@ function collectBookingAttribution() {
     ...storedAttribution,
     ...getMarketingConsentSignalPayload(fbclid)
   }
-}
-
-function getCompactFoodPrompt(value: string): string {
-  const arriveFromMatch = value.match(/arrive from\s+([^.\s]+)\s+for food/i)
-  if (arriveFromMatch?.[1]) {
-    return `Food from ${arriveFromMatch[1]}. Not a pre-order.`
-  }
-
-  return 'Not a food pre-order.'
 }
 
 function normalizeRemaining(value: unknown): number | null {
@@ -187,7 +163,6 @@ export function ManagementEventBookingForm({
   event,
   title,
   compact = false,
-  foodPrompt = 'Food is available before most hosted events. Book early if your group wants to eat first.'
 }: ManagementEventBookingFormProps) {
   const [phone, setPhone] = useState('')
   const [email, setEmail] = useState('')
@@ -201,7 +176,6 @@ export function ManagementEventBookingForm({
   // Per-ticket attendee names for tickets 2..N (ticket 1 is the booker above).
   // Only collected on paid events.
   const [additionalAttendeeNames, setAdditionalAttendeeNames] = useState<string[]>([])
-  const [foodIntent, setFoodIntent] = useState<FoodIntent>('planning_to_eat')
   const [seatingPreference, setSeatingPreference] = useState<EventSeatingPreference>('seated')
   const [submittedSeatingPreference, setSubmittedSeatingPreference] = useState<EventSeatingPreference | null>(null)
   const [loading, setLoading] = useState(false)
@@ -218,7 +192,6 @@ export function ManagementEventBookingForm({
   const formViewedTracked = useRef(false)
   const paymentCompleteTracked = useRef(false)
 
-  const selectedFoodIntent = FOOD_INTENT_OPTIONS.find((option) => option.value === foodIntent) || FOOD_INTENT_OPTIONS[0]
   const bookingReassurance = getEventBookingReassurance(event)
   const isCommunalEvent = isCommunalBookingMode(event.booking_mode)
   // Paid events require a name for every ticket (booker is ticket 1).
@@ -246,7 +219,6 @@ export function ManagementEventBookingForm({
     submittedSeatingPreference === 'seated' &&
     result?.event_seating_type === 'standing'
   const waitlistPlaceLabel = isCommunalEvent ? 'places' : 'seats'
-  const compactFoodPrompt = getCompactFoodPrompt(foodPrompt)
 
   useEffect(() => {
     if (!isCommunalEvent) {
@@ -289,10 +261,6 @@ export function ManagementEventBookingForm({
       source: 'event_booking_form'
     })
   }, [event.id, event.name, event.startDate])
-
-  function buildFoodNotes(): string {
-    return `Event dining intent: ${selectedFoodIntent.label}`
-  }
 
   async function handleSubmit(formEvent: FormEvent<HTMLFormElement>) {
     formEvent.preventDefault()
@@ -360,7 +328,6 @@ export function ManagementEventBookingForm({
       eventName: event.name,
       eventDate: event.startDate,
       partySize: clampedSeats,
-      foodIntent,
       source: 'event_booking_form'
     })
     trackEventBookingFunnelStep({
@@ -369,11 +336,9 @@ export function ManagementEventBookingForm({
       eventName: event.name,
       eventDate: event.startDate,
       partySize: clampedSeats,
-      foodIntent,
       source: 'event_booking_form'
     })
 
-    const notes = buildFoodNotes()
     const attribution = collectBookingAttribution()
     const totalValue = calculateBookingValue(event, clampedSeats)
     const bookingSeatingPreference = isCommunalEvent ? seatingPreference : null
@@ -395,8 +360,6 @@ export function ManagementEventBookingForm({
           seats: clampedSeats,
           ...(attendeeNames ? { attendee_names: attendeeNames } : {}),
           ...(bookingSeatingPreference ? { seating_preference: bookingSeatingPreference } : {}),
-          notes,
-          food_intent: foodIntent,
           event_slug: event.slug,
           event_name: event.name,
           event_date: event.startDate,
@@ -449,7 +412,7 @@ export function ManagementEventBookingForm({
           eventDate: event.startDate,
           tickets: clampedSeats,
           value: totalValue,
-          foodIntent,
+          foodIntent: null,
           attribution,
         })
       }
@@ -462,7 +425,6 @@ export function ManagementEventBookingForm({
           eventName: event.name,
           eventDate: event.startDate,
           partySize: clampedSeats,
-          foodIntent,
           bookingId: bookingData.booking_id,
           source: 'event_booking_form'
         })
@@ -475,7 +437,6 @@ export function ManagementEventBookingForm({
           eventDate: event.startDate,
           tickets: clampedSeats,
           totalValue,
-          foodIntent,
           bookingId: bookingData.booking_id
         })
       }
@@ -488,7 +449,6 @@ export function ManagementEventBookingForm({
           eventName: event.name,
           eventDate: event.startDate,
           partySize: clampedSeats,
-          foodIntent,
           reason: bookingData.reason,
           source: 'event_booking_form'
         })
@@ -501,7 +461,6 @@ export function ManagementEventBookingForm({
         eventName: event.name,
         eventDate: event.startDate,
         partySize: clampedSeats,
-        foodIntent,
         reason: submitError?.message || 'submission_error',
         source: 'event_booking_form'
       })
@@ -580,7 +539,6 @@ export function ManagementEventBookingForm({
           first_name: firstName.trim(),
           last_name: lastName.trim(),
           requested_seats: seats,
-          notes: buildFoodNotes(),
           communication_consent: buildCommunicationConsentPayload(communicationConsent),
           ...(turnstileToken ? { turnstile_token: turnstileToken } : {}),
           ...(honeypot ? { website: honeypot } : {}),
@@ -716,12 +674,17 @@ export function ManagementEventBookingForm({
           </div>
 
           {collectsAttendeeNames ? (
-            <fieldset className="space-y-2 rounded-sm border border-line bg-surface-sunk p-2.5">
+            <fieldset className="space-y-3 rounded-sm border border-line bg-surface-sunk p-3">
               <legend className="px-1 text-sm font-semibold text-ink">Who are the tickets for?</legend>
-              <p className="px-1 text-xs leading-relaxed text-ink-muted">
-                Ticket 1 is you. Add a name for each of the other {seats - 1} {seats - 1 === 1 ? 'ticket' : 'tickets'} so we know who to expect.
-              </p>
-              <div className="space-y-2">
+              <div className="space-y-1.5 px-1">
+                <p className="text-xs leading-relaxed text-ink-muted">
+                  Ticket 1 is you. Add the full name for each of the other {requiredAdditionalAttendeeCount} {requiredAdditionalAttendeeCount === 1 ? 'ticket' : 'tickets'}.
+                </p>
+                <p className="text-xs font-semibold leading-relaxed text-ink">
+                  Please use each guest’s real name — everyone will need photo ID matching their ticket on the night.
+                </p>
+              </div>
+              <div className="space-y-2.5">
                 {additionalAttendeeNames.map((name, index) => (
                   <Input
                     key={index}
@@ -734,7 +697,7 @@ export function ManagementEventBookingForm({
                         prev.map((existing, i) => (i === index ? inputEvent.target.value : existing))
                       )
                     }
-                    placeholder="Full name"
+                    placeholder="First and last name"
                     autoComplete="off"
                   />
                 ))}
@@ -781,20 +744,6 @@ export function ManagementEventBookingForm({
             onChange={setCommunicationConsent}
           />
 
-          <label className="flex cursor-pointer gap-2.5 rounded-sm border border-line bg-surface-sunk p-2.5">
-            <input
-              type="checkbox"
-              name="food_intent"
-              checked={foodIntent === 'planning_to_eat'}
-              onChange={(event) => setFoodIntent(event.target.checked ? 'planning_to_eat' : 'event_only')}
-              className="mt-1 h-4 w-4 flex-shrink-0 accent-anchor-gold-dark"
-            />
-            <span>
-              <span className="block text-sm font-semibold text-ink">Planning to eat before the event</span>
-              <span className="block text-xs leading-relaxed text-ink-muted">{compactFoodPrompt}</span>
-            </span>
-          </label>
-
           {/* Honeypot, hidden from real users, filled by bots */}
           <div aria-hidden="true" style={{ position: 'absolute', left: '-9999px', top: '-9999px', opacity: 0, height: 0, overflow: 'hidden' }}>
             <label htmlFor="evt-website">Website</label>
@@ -831,7 +780,6 @@ export function ManagementEventBookingForm({
                 eventName: event.name,
                 eventDate: event.startDate,
                 partySize: seats,
-                foodIntent,
                 source: 'event_booking_form'
               })
             }}

--- a/tests/unit/ManagementEventBookingForm.test.tsx
+++ b/tests/unit/ManagementEventBookingForm.test.tsx
@@ -84,8 +84,13 @@ describe('ManagementEventBookingForm', () => {
     expect(screen.getByLabelText('First name')).toBeInTheDocument()
     expect(screen.getByLabelText('Last name')).toBeInTheDocument()
     expect(screen.getByLabelText('Mobile number')).toBeInTheDocument()
-    expect(screen.getByRole('checkbox', { name: /Planning to eat before the event/i })).toBeChecked()
-    expect(screen.getByText('Not a food pre-order.')).toBeInTheDocument()
+    // The 'Planning to eat before the event' tickbox has been removed
+    expect(screen.queryByRole('checkbox', { name: /Planning to eat/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Not a food pre-order.')).not.toBeInTheDocument()
+    // Paid multi-ticket bookings collect a real name per ticket
+    expect(screen.getByText('Who are the tickets for?')).toBeInTheDocument()
+    expect(screen.getByText(/photo ID matching their ticket on the night/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('Ticket 2 name')).toBeInTheDocument()
     expect(screen.getByText('No payment now. Reserve seats online and pay £3 per person on arrival.')).toBeInTheDocument()
     expect(screen.getByText('18 seats currently available.')).toBeInTheDocument()
     expect(screen.queryByText('How many seats should we hold?')).not.toBeInTheDocument()
@@ -115,7 +120,7 @@ describe('ManagementEventBookingForm', () => {
     await waitFor(() => expect(screen.getByText('Sunday lunch only')).toBeInTheDocument())
   })
 
-  it('submits event dining intent without collecting pre-order notes', async () => {
+  it('submits per-ticket names and omits food fields', async () => {
     ;(global as any).fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString()
 
@@ -186,13 +191,15 @@ describe('ManagementEventBookingForm', () => {
             color: '#f2c94c'
           }
         }}
-        foodPrompt="Arrive from 6:30pm for food. Music Bingo starts at 8pm."
       />
     )
 
     fireEvent.change(screen.getByLabelText('Seats'), { target: { value: '6' } })
-    fireEvent.click(screen.getByRole('checkbox', { name: /Planning to eat before the event/i }))
-    expect(screen.queryByLabelText('Food notes (optional)')).not.toBeInTheDocument()
+    fireEvent.change(await screen.findByLabelText('Ticket 2 name'), { target: { value: 'Al Two' } })
+    fireEvent.change(screen.getByLabelText('Ticket 3 name'), { target: { value: 'Bo Three' } })
+    fireEvent.change(screen.getByLabelText('Ticket 4 name'), { target: { value: 'Cy Four' } })
+    fireEvent.change(screen.getByLabelText('Ticket 5 name'), { target: { value: 'Di Five' } })
+    fireEvent.change(screen.getByLabelText('Ticket 6 name'), { target: { value: 'Ez Six' } })
     fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Jane' } })
     fireEvent.change(screen.getByLabelText('Last name'), { target: { value: 'Guest' } })
     fireEvent.change(screen.getByLabelText('Mobile number'), { target: { value: '07700900000' } })
@@ -207,8 +214,9 @@ describe('ManagementEventBookingForm', () => {
     expect(payload.seats).toBe(6)
     expect(payload.first_name).toBe('Jane')
     expect(payload.last_name).toBe('Guest')
-    expect(payload.notes).toBe('Event dining intent: Event or drinks only')
-    expect(payload.food_intent).toBe('event_only')
+    expect(payload.attendee_names).toEqual(['Jane Guest', 'Al Two', 'Bo Three', 'Cy Four', 'Di Five', 'Ez Six'])
+    expect(payload.notes).toBeUndefined()
+    expect(payload.food_intent).toBeUndefined()
     expect(payload.event_slug).toBe('music-bingo')
     expect(payload.event_name).toBe('Music Bingo')
     expect(payload.event_category_name).toBe('Bingo')
@@ -242,7 +250,6 @@ describe('ManagementEventBookingForm', () => {
         eventDate: '2026-05-08T20:00:00+01:00',
         tickets: 6,
         totalValue: 36,
-        foodIntent: 'event_only',
         bookingId: 'booking-123'
       })
     )
@@ -303,6 +310,8 @@ describe('ManagementEventBookingForm', () => {
     await waitFor(() => expect(screen.getByRole('radio', { name: /Standing/i })).toBeChecked())
 
     fireEvent.change(screen.getByLabelText('Seats'), { target: { value: '3' } })
+    fireEvent.change(await screen.findByLabelText('Ticket 2 name'), { target: { value: 'Al Two' } })
+    fireEvent.change(screen.getByLabelText('Ticket 3 name'), { target: { value: 'Bo Three' } })
     fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Jane' } })
     fireEvent.change(screen.getByLabelText('Last name'), { target: { value: 'Guest' } })
     fireEvent.change(screen.getByLabelText('Mobile number'), { target: { value: '07700900000' } })
@@ -316,6 +325,7 @@ describe('ManagementEventBookingForm', () => {
 
     expect(payload.seats).toBe(3)
     expect(payload.seating_preference).toBe('standing')
+    expect(payload.attendee_names).toEqual(['Jane Guest', 'Al Two', 'Bo Three'])
     expect(payload.event_price).toBe(10)
     expect(payload.event_value).toBe(30)
   })
@@ -384,6 +394,9 @@ describe('ManagementEventBookingForm', () => {
     )
 
     fireEvent.change(screen.getByLabelText('Seats'), { target: { value: '4' } })
+    fireEvent.change(await screen.findByLabelText('Ticket 2 name'), { target: { value: 'Al Two' } })
+    fireEvent.change(screen.getByLabelText('Ticket 3 name'), { target: { value: 'Bo Three' } })
+    fireEvent.change(screen.getByLabelText('Ticket 4 name'), { target: { value: 'Cy Four' } })
     fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Jane' } })
     fireEvent.change(screen.getByLabelText('Last name'), { target: { value: 'Guest' } })
     fireEvent.change(screen.getByLabelText('Mobile number'), { target: { value: '07700900000' } })


### PR DESCRIPTION
## What
- **Removes the "Planning to eat before the event" tickbox** from the event booking form template (applies to all events), along with the food-intent plumbing it fed (state, options, booking `notes`, `food_intent` payload field, tracking args, and the now-unused `foodPrompt` prop on the form). The separate food-arrival copy shown elsewhere on the event page is left untouched.
- **Clarifies the "Who are the tickets for?" section:** tidier spacing/layout, a "First and last name" placeholder, and an explicit note that **real names must be used and photo ID will be required on the night**.
- Updates the form unit tests for the removed tickbox and the per-ticket name inputs.

## Why
The dining-intent tickbox was noise on the booking step, and for paid ticketed events staff need real attendee names that match photo ID on entry.

## Testing
- [x] `npx tsc --noEmit` clean, `npm run lint` (0 warnings), `npm run build` success
- [x] Jest: form unit tests + `/api/event-bookings` route tests pass (10)

## Deploy
Website is a **manual deploy** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)