### PR TITLE
feat(menu): add live kids menu to food page

### DIFF
--- a/app/food-menu/_components/FoodMenuSection.tsx
+++ b/app/food-menu/_components/FoodMenuSection.tsx
@@ -176,7 +176,7 @@ export function FoodMenuSection({ menuData, showFilters = true, showAllergens = 
       ) : (
         <div className="flex flex-col gap-12">
           {groups.map(group => (
-            <div key={group.id} id={group.id}>
+            <div key={group.id} id={group.id} className="scroll-mt-32">
               <h3 className="mb-5 font-display text-h3 text-ink-strong">{group.title}</h3>
               <Card accent>
                 <CardBody className="py-2">

--- a/app/food-menu/page.tsx
+++ b/app/food-menu/page.tsx
@@ -17,9 +17,11 @@ import { generateKitchenHoursSpecification, generateSuitableForDiet } from '@/li
 import { jsonLdSafeStringify } from '@/lib/jsonld'
 import { OrganicSearchClusterLinks } from '@/components/seo/OrganicSearchClusterLinks'
 import { BreadcrumbJsonLd } from '@/components/seo/BreadcrumbJsonLd'
+import { MenuAnchorNav } from '@/components/food/MenuAnchorNav'
 import {
   getFishAndChipsMenuPageData,
   getFoodMenuPageData,
+  getKidsMenuPageData,
   getMenuUnavailableMessage,
   getSundayLunchMenuPageData,
   type MenuPageItem
@@ -114,10 +116,14 @@ function isPrimaryFoodItem(item: MenuPageItem): boolean {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  const data = await getFoodMenuPageData()
+  const [data, kidsData] = await Promise.all([
+    getFoodMenuPageData(),
+    getKidsMenuPageData()
+  ])
   const pricePhrase = data?.priceFromLabel ? ` Dishes ${data.priceFromLabel}.` : ''
+  const kidsPhrase = kidsData?.items.length ? ' A dedicated kids menu is included.' : ''
   const description = data
-    ? `Pub food menu in Stanwell Moor near Heathrow T5, with live dishes and prices.${pricePhrase} Free parking, Sunday roast and table booking.`
+    ? `Pub food menu in Stanwell Moor near Heathrow T5, with live dishes and prices.${pricePhrase}${kidsPhrase} Free parking, Sunday roast and table booking.`
     : 'Food near Heathrow Airport at The Anchor. See the live pub menu with current dishes and prices from the kitchen.'
 
   return {
@@ -140,8 +146,9 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function FoodMenuPage() {
-  const [menuData, businessHours, fishData, sundayData] = await Promise.all([
+  const [menuData, kidsData, businessHours, fishData, sundayData] = await Promise.all([
     getFoodMenuPageData(),
+    getKidsMenuPageData(),
     getBusinessHours().catch(() => null),
     getFishAndChipsMenuPageData(),
     getSundayLunchMenuPageData()
@@ -158,7 +165,21 @@ export default async function FoodMenuPage() {
   }
 
   const kitchenSchedule = businessHours ? buildKitchenSchedule(businessHours) : ''
-  const menuSections = menuData.menuData.categories.map((category, index) => ({
+  const existingCategoryIds = new Set(menuData.menuData.categories.map(category => category.id))
+  const kidsCategories = (kidsData?.menuData.categories ?? [])
+    .filter(category => !existingCategoryIds.has(category.id))
+  const dessertIndex = menuData.menuData.categories.findIndex(category => /dessert/i.test(category.title))
+  const kidsInsertIndex = dessertIndex >= 0 ? dessertIndex : menuData.menuData.categories.length
+  const combinedCategories = [
+    ...menuData.menuData.categories.slice(0, kidsInsertIndex),
+    ...kidsCategories,
+    ...menuData.menuData.categories.slice(kidsInsertIndex)
+  ]
+  const combinedMenuData = {
+    ...menuData.menuData,
+    categories: combinedCategories
+  }
+  const menuSections = combinedCategories.map((category, index) => ({
     position: index + 1,
     name: category.title,
     url: `https://www.the-anchor.pub/food-menu#${category.id}`
@@ -166,6 +187,7 @@ export default async function FoodMenuPage() {
   const fishPreview = itemPreview(fishData?.fishItems ?? [])
   const primaryFoodPriceRange = getPriceRangeLabel(menuData.items.filter(isPrimaryFoodItem))
   const pizzaPriceFrom = getPriceFromLabel(menuData.pizzaItems)
+  const kidsPriceRange = getPriceRangeLabel(kidsData?.items ?? [])
 
   const faqItems = [
     {
@@ -186,7 +208,9 @@ export default async function FoodMenuPage() {
     },
     {
       question: "Is there a children's menu?",
-      answer: 'We have smaller portions and high chairs on request.'
+      answer: kidsData?.items.length
+        ? `Yes. Our live kids menu is included on this page${kidsPriceRange ? `, with dishes from ${kidsPriceRange}` : ''}. High chairs are available on request.`
+        : 'Yes. We have a dedicated kids menu, and high chairs are available on request.'
     },
     {
       question: 'Do you serve fish and chips?',
@@ -226,12 +250,12 @@ export default async function FoodMenuPage() {
         crumb="Food"
         kicker="Eat, Drink, Enjoy"
         title="Proper pub food, minutes from Heathrow"
-        lead="Pub classics, stone-baked pizzas, fish and chips and a proper Sunday roast in Stanwell Moor, seven minutes from Heathrow Terminal 5 with free parking."
+        lead="Pub classics, stone-baked pizzas, fish and chips, a dedicated kids menu and a proper Sunday roast in Stanwell Moor, seven minutes from Heathrow Terminal 5 with free parking."
         badges={
           <>
             <Badge variant="sand">{primaryFoodPriceRange ? `Food ${primaryFoodPriceRange}` : 'Live menu prices'}</Badge>
             <Badge variant="sand">{pizzaPriceFrom ? `Pizzas ${pizzaPriceFrom}` : 'Live pizza prices'}</Badge>
-            <Badge variant="sand">Dog friendly</Badge>
+            <Badge variant="sand">{kidsPriceRange ? `Kids' meals ${kidsPriceRange}` : 'Kids menu available'}</Badge>
           </>
         }
         actions={
@@ -265,9 +289,16 @@ export default async function FoodMenuPage() {
             kicker="The menu"
             script="Carved, baked, poured"
             title="Today at The Anchor"
-            lead="Everything below is the kitchen's current menu. All dishes are prepared in a single kitchen where allergens are present, so please tell the bar team about any requirements before ordering."
+            lead="Everything below is the kitchen's current food and kids menus. All dishes are prepared in a single kitchen where allergens are present, so please tell the bar team about any requirements before ordering."
           />
-          <FoodMenuSection menuData={menuData.menuData} />
+          <MenuAnchorNav
+            links={combinedCategories.map(category => ({
+              id: category.id,
+              label: category.title
+            }))}
+            className="mx-auto mb-10 max-w-[920px]"
+          />
+          <FoodMenuSection menuData={combinedMenuData} />
         </div>
       </section>
 
@@ -333,7 +364,7 @@ export default async function FoodMenuPage() {
               provider: { '@id': 'https://www.the-anchor.pub/#business' },
               name: 'The Anchor Food Menu',
               description: 'Current food menu near Heathrow Airport.',
-              hasMenuSection: menuData.menuData.categories.map(category => ({
+              hasMenuSection: combinedCategories.map(category => ({
                 '@type': 'MenuSection',
                 name: category.title,
                 description: category.description,

--- a/app/sitemap-page/page.tsx
+++ b/app/sitemap-page/page.tsx
@@ -66,6 +66,7 @@ const sitemapSections: SitemapSection[] = [
       { label: 'Sunday Roast', href: '/sunday-roast' },
       { label: 'Stone-Baked Pizza', href: '/pizza-menu' },
       { label: 'Fish & Chips', href: '/fish-and-chips-heathrow' },
+      { label: 'Kids Menu', href: '/food-menu#kids' },
       { label: 'Vegetarian Menu', href: '/food-menu/vegetarian' },
       { label: 'Vegan Options', href: '/food-menu/vegan' },
       { label: 'Gluten-Aware Menu', href: '/food-menu/gluten-free' },

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -79,6 +79,7 @@ const defaultItems: NavigationItem[] = [
       { label: 'Sunday Roast', href: '/sunday-roast', description: 'Carved fresh to order, every Sunday' },
       { label: 'Stone-Baked Pizza', href: '/pizza-menu', description: 'Hand-stretched pizzas from the live menu' },
       { label: 'Fish & Chips', href: '/fish-and-chips-heathrow', description: 'A proper chippy tea near Heathrow' },
+      { label: 'Kids Menu', href: '/food-menu#kids', description: 'Children’s dishes and current prices' },
       { label: 'Vegetarian & Vegan', href: '/food-menu/vegan', description: 'Plant-based dishes and vegan options' },
       { label: 'Gluten-free options', href: '/food-menu/gluten-free', description: 'Gluten-free choices and allergen guidance' },
       { label: 'Drinks Menu', href: '/drinks', description: 'Draught pints, cocktails, wine and soft drinks' }

--- a/lib/api/menu.ts
+++ b/lib/api/menu.ts
@@ -124,6 +124,9 @@ export const FALLBACK_SUNDAY_LUNCH_MENU: SundayLunchMenuResponse = {
 /** Menu code for the standard website food menu. */
 export const DEFAULT_FOOD_MENU_CODE = 'website_food'
 
+/** Menu code for the separate children's menu. */
+export const KIDS_MENU_CODE = 'kids'
+
 /** Menu code for the seasonal Christmas menu. */
 export const CHRISTMAS_MENU_CODE = 'christmas'
 

--- a/lib/food-menu-section-order.ts
+++ b/lib/food-menu-section-order.ts
@@ -7,7 +7,8 @@ const FOOD_MENU_SECTION_DISPLAY_ORDER = new Map([
   ['burgers', 2],
   ['snack-pots', 3],
   ['light-bites', 4],
-  ['desserts', 5]
+  ['kids', 5],
+  ['desserts', 6]
 ])
 
 function slugify(value: string): string {

--- a/lib/menu-page-data.ts
+++ b/lib/menu-page-data.ts
@@ -7,6 +7,7 @@ import type {
   SundayLunchMenuItem,
   SundayLunchMenuResponse
 } from '@/lib/api/menu'
+import { KIDS_MENU_CODE } from '@/lib/api/menu'
 import type { MenuData, MenuItem } from '@/lib/menu-parser'
 import { sortFoodMenuSections } from '@/lib/food-menu-section-order'
 import ssot from '@/SSOT.json'
@@ -336,7 +337,11 @@ function fishPagePriority(item: MenuPageItem): number {
   return 3
 }
 
-function buildMenuData(response: MenuResponse): MenuData | null {
+function buildMenuData(
+  response: MenuResponse,
+  title = 'The Anchor Food Menu',
+  description = 'Current food menu at The Anchor.'
+): MenuData | null {
   const sections = sortFoodMenuSections(Array.isArray(response.sections) ? response.sections : [])
   if (sections.length === 0) return null
 
@@ -365,8 +370,8 @@ function buildMenuData(response: MenuResponse): MenuData | null {
   if (categories.length === 0) return null
 
   return {
-    title: 'The Anchor Food Menu',
-    description: 'Current food menu at The Anchor.',
+    title,
+    description,
     lastUpdated: (((response.menu as unknown) as Record<string, unknown>)?.lastUpdated as string | undefined) || String(CURRENT_YEAR),
     categories
   }
@@ -622,6 +627,21 @@ async function fetchChristmasMenuPageData(): Promise<ChristmasMenuPageData> {
 }
 
 export const getFoodMenuPageData = cache(fetchFoodMenuData)
+
+export const getKidsMenuPageData = cache(async (): Promise<MenuPageData | null> => {
+  try {
+    const response = await anchorAPI.getMenu(KIDS_MENU_CODE)
+    const menuData = buildMenuData(
+      response,
+      'The Anchor Kids Menu',
+      'Current children’s menu at The Anchor.'
+    )
+    return menuData ? buildMenuPageData(menuData) : null
+  } catch (error) {
+    console.warn('[menu-page-data] Failed to fetch kids menu', error)
+    return null
+  }
+})
 
 export const getPizzaMenuPageData = cache(async () => {
   const data = await fetchFoodMenuData()

--- a/tests/unit/kids-menu-page-data.test.ts
+++ b/tests/unit/kids-menu-page-data.test.ts
@@ -1,0 +1,60 @@
+import { anchorAPI } from '@/lib/api'
+import { getKidsMenuPageData } from '@/lib/menu-page-data'
+
+jest.mock('react', () => {
+  const actual = jest.requireActual('react')
+  return {
+    ...actual,
+    cache: (fn: unknown) => fn
+  }
+})
+
+jest.mock('@/lib/api', () => ({
+  anchorAPI: {
+    getMenu: jest.fn()
+  }
+}))
+
+describe('kids menu page data', () => {
+  it('loads the separate live kids menu', async () => {
+    jest.mocked(anchorAPI.getMenu).mockResolvedValue({
+      menu: {
+        '@context': 'https://schema.org',
+        '@type': 'Menu',
+        name: 'Kids Menu',
+        hasMenuSection: []
+      },
+      sections: [
+        {
+          id: 'kids',
+          name: 'Kids',
+          description: "Children's dishes",
+          sort_order: 1,
+          items: [
+            {
+              id: 'kids-dish-1',
+              name: 'Kids Test Dish',
+              description: 'A child-sized meal.',
+              price: 7,
+              dietary_info: [],
+              allergens: ['gluten'],
+              is_available: true,
+              sort_order: 1
+            }
+          ]
+        }
+      ]
+    })
+
+    const data = await getKidsMenuPageData()
+
+    expect(anchorAPI.getMenu).toHaveBeenCalledWith('kids')
+    expect(data?.menuData.title).toBe('The Anchor Kids Menu')
+    expect(data?.items).toHaveLength(1)
+    expect(data?.items[0]).toMatchObject({
+      name: 'Kids Test Dish',
+      priceValue: 7,
+      categoryId: 'kids'
+    })
+  })
+})

--- a/tests/unit/menu-page-data-order.test.ts
+++ b/tests/unit/menu-page-data-order.test.ts
@@ -18,6 +18,7 @@ describe('food menu section order', () => {
       section('Burgers', 40),
       section('Pizza', 50),
       section('Mains', 70),
+      section('Kids', 90),
       section('Desserts', 100)
     ]
 
@@ -27,6 +28,7 @@ describe('food menu section order', () => {
       'Burgers',
       'Snack Pots',
       'Light Bites',
+      'Kids',
       'Desserts'
     ])
   })


### PR DESCRIPTION
## What changed
- Loads the separate live kids menu from management
- Adds the kids section to the food menu, navigation, FAQ and structured data
- Adds focused menu data and ordering tests

## Why
Families could not see the existing kids menu on the website because it was stored separately from the main food menu.

## Checks
- Focused Jest tests
- TypeScript check
- Menu page audit
- Production build
- Local end-to-end check against the management database