### PR TITLE
fix: keep past event pages live and indexed, and correct their state

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -35,7 +35,7 @@ import {
 import { getEventPriceLabel } from '@/lib/event-pricing'
 import { getEventBookingCopy } from '@/lib/event-booking-copy'
 import { getEventBookingHeroStatement } from '@/lib/event-booking-experience'
-import { getEventSeoStrategy, getCategoryPageUrl, isDiscontinuedFormatEvent, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
+import { getEventSeoStrategy, getCategoryPageUrl, isDiscontinuedFormatEvent, getDiscontinuedFormatReplacement, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
 import { getEventPresentation } from '@/lib/event-presentation'
 import { getUpcomingEventsByCategory, isRetiredEvent } from '@/lib/api/events'
 import type { Event } from '@/lib/api'
@@ -342,7 +342,12 @@ export default async function EventPage({ params }: Props) {
       ? SALES_CLOSED_COPY
       : null
   const bookingFormSuppressed = !presentation.showBookingForm
-  const categoryPageUrl = getCategoryPageUrl(event.category?.slug)
+  // A discontinued format has no category page worth sending people to, so it
+  // points at the format that replaced it rather than a generic listing.
+  const discontinuedReplacement = getDiscontinuedFormatReplacement(event)
+  const categoryPageUrl = discontinuedReplacement?.href ?? getCategoryPageUrl(event.category?.slug)
+  const categoryPageLabel =
+    discontinuedReplacement?.label ?? `All ${event.category?.name} dates`
   const nextEventHref = nextInCategory ? getEventWebsitePath(nextInCategory) : null
   const nextEventDate = nextInCategory ? formatEventDate(nextInCategory.startDate) : null
 
@@ -799,11 +804,13 @@ export default async function EventPage({ params }: Props) {
         <CtaBand
           title="Looking for the next one?"
           copy={
-            nextEventDate && event.category?.name
-              ? `This night has finished. The next ${event.category.name} is ${nextEventDate}.`
-              : event.category?.name
-                ? `This night has finished. See when ${event.category.name} is on next, or browse everything coming up at The Anchor.`
-                : 'This night has finished. Browse everything coming up at The Anchor.'
+            discontinuedReplacement
+              ? discontinuedReplacement.copy
+              : nextEventDate && event.category?.name
+                ? `This night has finished. The next ${event.category.name} is ${nextEventDate}.`
+                : event.category?.name
+                  ? `This night has finished. See when ${event.category.name} is on next, or browse everything coming up at The Anchor.`
+                  : 'This night has finished. Browse everything coming up at The Anchor.'
           }
         >
           {nextEventHref ? (
@@ -818,9 +825,7 @@ export default async function EventPage({ params }: Props) {
               size="lg"
               className="w-full sm:w-auto"
             >
-              <Link href={categoryPageUrl}>
-                All {event.category?.name} dates
-              </Link>
+              <Link href={categoryPageUrl}>{categoryPageLabel}</Link>
             </Button>
           )}
           <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -12,6 +12,7 @@ import { anchorAPI, formatEventDate, formatEventTime, formatDoorTime, formatEven
 import { EventPageTracker } from '@/components/tracking/EventPageTracker'
 import { PhoneButton } from '@/components/PhoneButton'
 import { getTwitterMetadata } from '@/lib/twitter-metadata'
+import { getEventWebsitePath } from '@/lib/event-url'
 import { EventSecondaryActions } from '@/components/events/EventSecondaryActions'
 import { EventBookingFactsStrip } from '@/components/events/EventBookingFactsStrip'
 import { ManagementEventBookingForm } from '@/components/features/EventBooking/ManagementEventBookingForm'
@@ -34,9 +35,10 @@ import {
 import { getEventPriceLabel } from '@/lib/event-pricing'
 import { getEventBookingCopy } from '@/lib/event-booking-copy'
 import { getEventBookingHeroStatement } from '@/lib/event-booking-experience'
-import { getEventSeoStrategy, getCategoryPageUrl, PAST_EVENT_REDIRECT_DAYS, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
+import { getEventSeoStrategy, getCategoryPageUrl, isDiscontinuedFormatEvent, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
 import { getEventPresentation } from '@/lib/event-presentation'
-import { isRetiredEvent } from '@/lib/api/events'
+import { getUpcomingEventsByCategory, isRetiredEvent } from '@/lib/api/events'
+import type { Event } from '@/lib/api'
 import RelatedEvents from '@/components/events/RelatedEvents'
 import LiteYouTube from '@/components/events/LiteYouTube'
 
@@ -224,13 +226,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       event.description ||
       `Join us for ${event.name} at The Anchor in Stanwell Moor. ${formatEventDate(event.startDate)} at ${formatEventTime(event.startDate)}.`
     
-    // Determine if event should be noindexed
+    // Past events stay indexed indefinitely so each night's content can
+    // accumulate. Only a long-cancelled event is noindexed: nothing happened,
+    // so there is nothing worth ranking.
     const eventDate = Date.parse(event.startDate)
     const daysSinceEvent = (Date.now() - eventDate) / (1000 * 60 * 60 * 24)
     const eventStatus = normalizeEventStatus(event)
     const shouldNoindex =
-      (daysSinceEvent > PAST_EVENT_REDIRECT_DAYS) ||
-      (eventStatus === 'cancelled' && daysSinceEvent > CANCELLED_INDEX_DAYS)
+      (eventStatus === 'cancelled' && daysSinceEvent > CANCELLED_INDEX_DAYS) ||
+      // SSOT: discontinued formats must not be promoted. Page stays live for
+      // anyone holding the link, but out of search.
+      isDiscontinuedFormatEvent(event)
 
     // Merge keyword arrays
     const keywords = [
@@ -303,15 +309,21 @@ export default async function EventPage({ params }: Props) {
     permanentRedirect('/whats-on')
   }
 
-  // Event lifecycle SEO strategy: a stale past event 301s to its permanent
-  // category page. The destination no longer depends on what happens to be
-  // scheduled next, so there is no per-request lookup here any more.
+  // Past events are never redirected. The page stays live and indexed so its
+  // content keeps accumulating; the route into the next date is the on-page
+  // link built below, not a 301.
   const isPastEvent = isEventInPast(event)
-  if (isPastEvent) {
-    const seoStrategy = getEventSeoStrategy(event)
+  const seoStrategy = getEventSeoStrategy(event)
 
-    if (seoStrategy.redirect) {
-      permanentRedirect(seoStrategy.redirect)
+  // The next date in this category, used to point visitors (and link equity)
+  // at the live event. Display only, it never changes what URL is served.
+  let nextInCategory: Event | null = null
+  if (isPastEvent && event.category?.id && status !== 'cancelled') {
+    try {
+      const upcoming = await getUpcomingEventsByCategory(event.category.id, 1)
+      nextInCategory = upcoming.find((e) => e.id !== event.id) || null
+    } catch {
+      nextInCategory = null
     }
   }
 
@@ -331,6 +343,8 @@ export default async function EventPage({ params }: Props) {
       : null
   const bookingFormSuppressed = !presentation.showBookingForm
   const categoryPageUrl = getCategoryPageUrl(event.category?.slug)
+  const nextEventHref = nextInCategory ? getEventWebsitePath(nextInCategory) : null
+  const nextEventDate = nextInCategory ? formatEventDate(nextInCategory.startDate) : null
 
   const eventDate = formatEventDate(event.startDate)
   const statusNotice = getStatusNotice(status, isPastEvent, eventDate)
@@ -454,6 +468,13 @@ export default async function EventPage({ params }: Props) {
             <div className="mx-auto max-w-6xl">
               <Alert variant={statusNotice.variant} title={statusNotice.title}>
                 <p>{statusNotice.message}</p>
+                {nextEventHref && (
+                  <p className="mt-2">
+                    <Link href={nextEventHref} className="font-semibold underline">
+                      Next {event.category?.name || 'event'}: {nextEventDate}
+                    </Link>
+                  </p>
+                )}
               </Alert>
             </div>
           </Container>
@@ -778,13 +799,25 @@ export default async function EventPage({ params }: Props) {
         <CtaBand
           title="Looking for the next one?"
           copy={
-            event.category?.name
-              ? `This night has finished. See when ${event.category.name} is on next, or browse everything coming up at The Anchor.`
-              : 'This night has finished. Browse everything coming up at The Anchor.'
+            nextEventDate && event.category?.name
+              ? `This night has finished. The next ${event.category.name} is ${nextEventDate}.`
+              : event.category?.name
+                ? `This night has finished. See when ${event.category.name} is on next, or browse everything coming up at The Anchor.`
+                : 'This night has finished. Browse everything coming up at The Anchor.'
           }
         >
-          {categoryPageUrl !== '/whats-on' && (
+          {nextEventHref ? (
             <Button asChild size="lg" className="w-full sm:w-auto">
+              <Link href={nextEventHref}>Book the next one</Link>
+            </Button>
+          ) : null}
+          {categoryPageUrl !== '/whats-on' && (
+            <Button
+              asChild
+              variant={nextEventHref ? 'outline' : 'primary'}
+              size="lg"
+              className="w-full sm:w-auto"
+            >
               <Link href={categoryPageUrl}>
                 All {event.category?.name} dates
               </Link>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -35,6 +35,7 @@ import { getEventPriceLabel } from '@/lib/event-pricing'
 import { getEventBookingCopy } from '@/lib/event-booking-copy'
 import { getEventBookingHeroStatement } from '@/lib/event-booking-experience'
 import { getEventSeoStrategy, getCategoryPageUrl, isFallbackEvent, PAST_EVENT_REDIRECT_DAYS, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
+import { getEventPresentation } from '@/lib/event-presentation'
 import { getUpcomingEventsByCategory, isRetiredEvent } from '@/lib/api/events'
 import RelatedEvents from '@/components/events/RelatedEvents'
 import LiteYouTube from '@/components/events/LiteYouTube'
@@ -43,7 +44,11 @@ type Props = {
   params: { id: string }
 }
 
-function getStatusNotice(status: ReturnType<typeof normalizeEventStatus>, pastEvent: boolean): {
+function getStatusNotice(
+  status: ReturnType<typeof normalizeEventStatus>,
+  pastEvent: boolean,
+  eventDate?: string
+): {
   variant: 'info' | 'warning'
   title: string
   message: string
@@ -84,7 +89,9 @@ function getStatusNotice(status: ReturnType<typeof normalizeEventStatus>, pastEv
     return {
       variant: 'info',
       title: 'This event has ended',
-      message: 'Browse our upcoming events for the latest listings.'
+      message: eventDate
+        ? `It took place on ${eventDate}. See below for the next dates.`
+        : 'See below for the next dates.'
     }
   }
 
@@ -319,6 +326,11 @@ export default async function EventPage({ params }: Props) {
     }
   }
 
+  // Single source of truth for which booking surfaces render. Also drives the
+  // JSON-LD via buildEventSchema, so the page and the schema cannot disagree
+  // about whether this event is over.
+  const presentation = getEventPresentation(event)
+
   const bookingBlockReason = getEventBookingBlockReason(event)
   // Online ticket sales cutoff: distinct, friendly "sales closed" panel. Only
   // surfaced when nothing more specific (cancelled / sold out / past) applies.
@@ -328,11 +340,11 @@ export default async function EventPage({ params }: Props) {
     : bookingClosedByCutoff
       ? SALES_CLOSED_COPY
       : null
-  // The online booking form is hidden whenever a block reason OR the cutoff applies.
-  const bookingFormSuppressed = Boolean(bookingBlockReason) || bookingClosedByCutoff
-  const statusNotice = getStatusNotice(status, isPastEvent)
+  const bookingFormSuppressed = !presentation.showBookingForm
+  const categoryPageUrl = getCategoryPageUrl(event.category?.slug)
 
   const eventDate = formatEventDate(event.startDate)
+  const statusNotice = getStatusNotice(status, isPastEvent, eventDate)
   const eventTime = formatEventTime(event.startDate)
   const headerDoorTime = formatDoorTime(event.doorTime)
   const eventBookingCopy = getEventBookingCopy(event)
@@ -426,7 +438,9 @@ export default async function EventPage({ params }: Props) {
     { label: 'Doors open', value: doorsTime },
     { label: 'Last entry', value: lastEntryTime },
     { label: 'Duration', value: durationLabel },
-    { label: 'Status', value: statusLabel },
+    // "Scheduled" on a night that has already happened reads as though it is
+    // still going ahead. "Cancelled" is still worth showing.
+    ...(presentation.showStatusRow ? [{ label: 'Status', value: statusLabel }] : []),
     { label: 'Booking type', value: bookingModeLabel },
     { label: 'Event type', value: event.event_type },
     { label: 'Category', value: event.category?.name },
@@ -486,6 +500,7 @@ export default async function EventPage({ params }: Props) {
               event={event}
               eventDate={eventDate}
               eventTime={eventTime}
+              variant={presentation.factsVariant}
             />
           </div>
         </Container>
@@ -534,15 +549,17 @@ export default async function EventPage({ params }: Props) {
                   </CardBody>
                 </Card>
 
-                <Card accent className="mb-6 hidden lg:mb-8 lg:block">
-                  <CardBody className="p-4">
-                    <h2 className="text-lg font-semibold text-accent-text md:text-xl">Booking and payment</h2>
-                    <div className="mt-3 space-y-2 text-sm text-ink-muted">
-                      <p>{eventBookingCopy.policy}</p>
-                      <p>{eventBookingCopy.foodPrompt}</p>
-                    </div>
-                  </CardBody>
-                </Card>
+                {presentation.showBookingPolicy && (
+                  <Card accent className="mb-6 hidden lg:mb-8 lg:block">
+                    <CardBody className="p-4">
+                      <h2 className="text-lg font-semibold text-accent-text md:text-xl">Booking and payment</h2>
+                      <div className="mt-3 space-y-2 text-sm text-ink-muted">
+                        <p>{eventBookingCopy.policy}</p>
+                        <p>{eventBookingCopy.foodPrompt}</p>
+                      </div>
+                    </CardBody>
+                  </Card>
+                )}
 
                 {/* Description */}
                 {(event.longDescription || event.about || event.description) && (
@@ -616,14 +633,16 @@ export default async function EventPage({ params }: Props) {
                     )}
                   </div>
 
-                  <div className="mb-6 hidden lg:block">
-                    <EventSecondaryActions
-                      event={event}
-                      source="event_page_sidebar_actions"
-                      className="justify-start"
-                      size="sm"
-                    />
-                  </div>
+                  {presentation.showShareButton && (
+                    <div className="mb-6 hidden lg:block">
+                      <EventSecondaryActions
+                        event={event}
+                        source="event_page_sidebar_actions"
+                        className="justify-start"
+                        size="sm"
+                      />
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -679,8 +698,11 @@ export default async function EventPage({ params }: Props) {
                 </div>
               )}
 
-              {/* FAQs */}
-              {((event.faq && event.faq.length > 0) || (event.faqPage && event.faqPage.mainEntity.length > 0)) && (
+              {/* FAQs. Overwhelmingly booking questions, so they are hidden once
+                  the event is over rather than telling visitors how to book a
+                  night that has already happened. */}
+              {presentation.showBookingFaqs &&
+                ((event.faq && event.faq.length > 0) || (event.faqPage && event.faqPage.mainEntity.length > 0)) && (
                 <div>
                   <h2 className="text-xl md:text-2xl text-accent-text mb-4 md:mb-6">Frequently Asked Questions</h2>
                   <div className="space-y-3 md:space-y-4">
@@ -730,36 +752,60 @@ export default async function EventPage({ params }: Props) {
         </Container>
       </section>
 
-      {/* CTA Section */}
-      <CtaBand
-        title={isCommunalEvent ? 'Ready to book your event tickets?' : 'Ready to reserve your event table?'}
-        copy={mothersDayBookingFlow ? mothersDayBookingCopy : getEventBookingHeroStatement(event)}
-      >
-        {mothersDayBookingFlow ? (
-          <Button asChild size="lg" className="w-full sm:w-auto">
-            <Link href={mothersDayBookingUrl}>{MOTHERS_DAY_BOOKING_CTA_LABEL}</Link>
-          </Button>
-        ) : bookingFormSuppressed ? null : (
-          <EventBookingButton
-            event={event}
-            className="w-full sm:w-auto"
-            fullWidth={false}
-            size="lg"
-            label={bookingCtaLabel}
-            customHref="#event-booking"
-            source={`event_page_cta_${params.id}`}
-          />
-        )}
-        <PhoneButton
-          phone="01753682707"
-          source={`event_page_${params.id}`}
-          variant="outline"
-          size="lg"
-          className="w-full sm:w-auto"
+      {/* CTA Section. Once the event is over the booking band is replaced with a
+          route into the next one rather than an invitation to book a date that
+          has already passed. */}
+      {presentation.showBookingCtaBand ? (
+        <CtaBand
+          title={isCommunalEvent ? 'Ready to book your event tickets?' : 'Ready to reserve your event table?'}
+          copy={mothersDayBookingFlow ? mothersDayBookingCopy : getEventBookingHeroStatement(event)}
         >
-          Call: 01753 682707
-        </PhoneButton>
-      </CtaBand>
+          {mothersDayBookingFlow ? (
+            <Button asChild size="lg" className="w-full sm:w-auto">
+              <Link href={mothersDayBookingUrl}>{MOTHERS_DAY_BOOKING_CTA_LABEL}</Link>
+            </Button>
+          ) : bookingFormSuppressed ? null : (
+            <EventBookingButton
+              event={event}
+              className="w-full sm:w-auto"
+              fullWidth={false}
+              size="lg"
+              label={bookingCtaLabel}
+              customHref="#event-booking"
+              source={`event_page_cta_${params.id}`}
+            />
+          )}
+          <PhoneButton
+            phone="01753682707"
+            source={`event_page_${params.id}`}
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto"
+          >
+            Call: 01753 682707
+          </PhoneButton>
+        </CtaBand>
+      ) : (
+        <CtaBand
+          title="Looking for the next one?"
+          copy={
+            event.category?.name
+              ? `This night has finished. See when ${event.category.name} is on next, or browse everything coming up at The Anchor.`
+              : 'This night has finished. Browse everything coming up at The Anchor.'
+          }
+        >
+          {categoryPageUrl !== '/whats-on' && (
+            <Button asChild size="lg" className="w-full sm:w-auto">
+              <Link href={categoryPageUrl}>
+                All {event.category?.name} dates
+              </Link>
+            </Button>
+          )}
+          <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
+            <Link href="/whats-on">See what&rsquo;s on</Link>
+          </Button>
+        </CtaBand>
+      )}
     </>
   )
 }

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -34,9 +34,9 @@ import {
 import { getEventPriceLabel } from '@/lib/event-pricing'
 import { getEventBookingCopy } from '@/lib/event-booking-copy'
 import { getEventBookingHeroStatement } from '@/lib/event-booking-experience'
-import { getEventSeoStrategy, getCategoryPageUrl, isFallbackEvent, PAST_EVENT_REDIRECT_DAYS, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
+import { getEventSeoStrategy, getCategoryPageUrl, PAST_EVENT_REDIRECT_DAYS, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
 import { getEventPresentation } from '@/lib/event-presentation'
-import { getUpcomingEventsByCategory, isRetiredEvent } from '@/lib/api/events'
+import { isRetiredEvent } from '@/lib/api/events'
 import RelatedEvents from '@/components/events/RelatedEvents'
 import LiteYouTube from '@/components/events/LiteYouTube'
 
@@ -303,23 +303,12 @@ export default async function EventPage({ params }: Props) {
     permanentRedirect('/whats-on')
   }
 
-  // Event lifecycle SEO strategy, redirect stale past events to next upcoming event
+  // Event lifecycle SEO strategy: a stale past event 301s to its permanent
+  // category page. The destination no longer depends on what happens to be
+  // scheduled next, so there is no per-request lookup here any more.
   const isPastEvent = isEventInPast(event)
   if (isPastEvent) {
-    // Only look up the next event for past (non-cancelled) events.
-    // Cancelled events never redirect, they render with a cancelled banner.
-    let nextEvent = null
-    if (event.category?.id && normalizeEventStatus(event) !== 'cancelled') {
-      try {
-        const upcoming = await getUpcomingEventsByCategory(event.category.id, 1)
-        const validUpcoming = upcoming.filter(e => !isFallbackEvent(e) && e.id !== params.id)
-        nextEvent = validUpcoming[0] || null
-      } catch {
-        nextEvent = null
-      }
-    }
-
-    const seoStrategy = getEventSeoStrategy(event, nextEvent)
+    const seoStrategy = getEventSeoStrategy(event)
 
     if (seoStrategy.redirect) {
       permanentRedirect(seoStrategy.redirect)

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { getAllBlogPosts } from '@/lib/markdown'
 import { landmarks } from '@/lib/local-seo-data'
 import { anchorAPI, type Event } from '@/lib/api'
 import { getEventWebsitePath } from '@/lib/event-url'
-import { PAST_EVENT_REDIRECT_DAYS, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
+import { CANCELLED_INDEX_DAYS, isDiscontinuedFormatEvent } from '@/lib/event-seo-strategy'
 import { isRetiredEvent } from '@/lib/api/events'
 
 export const revalidate = 60 * 60 // 1 hour
@@ -294,10 +294,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const eventDate = Date.parse(event.startDate)
       const daysSince = (nowMs - eventDate) / (1000 * 60 * 60 * 24)
 
-      // Exclude stale past events (30+ days old)
-      if (daysSince > PAST_EVENT_REDIRECT_DAYS) return false
+      // Past events stay listed. They remain live and indexed, so excluding
+      // them from the sitemap would just slow down how often Google recrawls
+      // the very pages this policy exists to let accumulate.
 
-      // Exclude cancelled events older than 7 days
+      // Formats the SSOT says are discontinued are noindex, so they must not
+      // be listed here either.
+      if (isDiscontinuedFormatEvent(event)) return false
+
+      // Cancelled events are the exception: nothing happened, so there is no
+      // content worth ranking, and they go noindex after 7 days.
       const status = event.event_status || event.eventStatus || ''
       const isCancelled = status.toLowerCase().includes('cancelled')
       if (isCancelled && daysSince > CANCELLED_INDEX_DAYS) return false

--- a/components/events/EventBookingFactsStrip.tsx
+++ b/components/events/EventBookingFactsStrip.tsx
@@ -2,6 +2,7 @@
 
 import { CalendarDays, Car, Clock, PoundSterling, type LucideIcon } from 'lucide-react'
 import type { Event } from '@/lib/api'
+import type { EventFactsVariant } from '@/lib/event-presentation'
 import { formatEventLocalDate } from '@/lib/event-calendar'
 import { getEventPriceLabel } from '@/lib/event-pricing'
 
@@ -15,24 +16,29 @@ type EventBookingFactsStripProps = {
   event: Event
   eventDate: string
   eventTime: string
+  /** 'historic' switches the labels to past tense for an event that has been and gone. */
+  variant?: EventFactsVariant
 }
 
 export function EventBookingFactsStrip({
   event,
   eventDate,
-  eventTime
+  eventTime,
+  variant = 'live'
 }: EventBookingFactsStripProps) {
+  const isHistoric = variant === 'historic'
   const compactDate = formatEventLocalDate(event.startDate, {
     weekday: 'short',
     day: 'numeric',
     month: 'short'
   })
-  const priceLabel = getEventPriceLabel(event) || 'Check booking step'
+  const priceLabel =
+    getEventPriceLabel(event) || (isHistoric ? 'See event details' : 'Check booking step')
 
   const facts: Fact[] = [
-    { label: 'Date', value: compactDate || eventDate, Icon: CalendarDays },
-    { label: 'Price', value: priceLabel, Icon: PoundSterling },
-    { label: 'Start', value: eventTime, Icon: Clock },
+    { label: isHistoric ? 'Took place' : 'Date', value: compactDate || eventDate, Icon: CalendarDays },
+    { label: isHistoric ? 'Entry was' : 'Price', value: priceLabel, Icon: PoundSterling },
+    { label: isHistoric ? 'Started' : 'Start', value: eventTime, Icon: Clock },
     { label: 'Parking', value: 'Free parking, 20 spaces', Icon: Car }
   ]
 

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -4,6 +4,7 @@ import { DEFAULT_EVENT_IMAGE } from '@/lib/image-fallbacks'
 import { logError } from '@/lib/error-handling'
 import { formatEventLocalDate, formatEventLocalTime } from '@/lib/event-calendar'
 import { dedupeUpcomingEvents } from '@/lib/event-normalization'
+import { RECENT_EVENT_WINDOW_DAYS } from '@/lib/event-seo-strategy'
 
 /**
  * A purchasable ticket type on an event (e.g. Adult / Child / Concession, or
@@ -590,7 +591,9 @@ export function hasLimitedAvailability(event: Event): boolean {
 
 // Standalone helpers that use the singleton (imported lazily to avoid circulars)
 const MAX_EVENTS_LIMIT = 100
-const RECENT_EVENT_DEFAULT_DAYS = 30
+// Shared with the event page's own "recent" wording. Previously a separate 30
+// declared here, which had to agree with the one in event-seo-strategy by hand.
+const RECENT_EVENT_DEFAULT_DAYS = RECENT_EVENT_WINDOW_DAYS
 
 export async function getUpcomingEvents(limit: number = 10, daysLookahead?: number): Promise<Event[]> {
   // Import lazily to avoid circular dependency with client.ts

--- a/lib/event-presentation.ts
+++ b/lib/event-presentation.ts
@@ -1,0 +1,91 @@
+import type { Event } from '@/lib/api'
+import {
+  getEventBookingBlockReason,
+  isEventBookingClosed,
+  isEventInPast,
+  normalizeEventStatus
+} from '@/lib/event-lifecycle'
+
+/**
+ * Single source of truth for how an event page renders.
+ *
+ * Both the page (`app/events/[id]/page.tsx`) and the structured data
+ * (`lib/structured-data/event-schema.ts`) resolve their conditionals from this
+ * module. That is deliberate: before it existed, the page derived
+ * `bookingFormSuppressed` locally and gated only three of nine booking-related
+ * surfaces with it, so an ended event still rendered a booking policy card,
+ * booking FAQs and a "Ready to book" CTA, while the JSON-LD advertised the
+ * event as `InStock`. Any new booking surface must read its flag from here
+ * rather than recomputing "is this event over" locally.
+ */
+
+export type EventPhase = 'upcoming' | 'ended' | 'cancelled'
+
+/** How the facts strip presents itself: live booking facts vs historical record. */
+export type EventFactsVariant = 'live' | 'historic'
+
+export interface EventPresentation {
+  phase: EventPhase
+  /** True once the event date has passed, whatever its status. */
+  hasEnded: boolean
+  /** The online booking form itself. */
+  showBookingForm: boolean
+  /** The "Booking and payment" policy card. */
+  showBookingPolicy: boolean
+  /** Event FAQs, which are overwhelmingly booking questions. */
+  showBookingFaqs: boolean
+  /** The closing "Ready to book" band. */
+  showBookingCtaBand: boolean
+  /** Share button, which invites sharing a night nobody can attend. */
+  showShareButton: boolean
+  /** The "Status: Scheduled" row in the event information list. */
+  showStatusRow: boolean
+  factsVariant: EventFactsVariant
+  /** Whether the JSON-LD should carry an `offers` object. */
+  includeSchemaOffers: boolean
+}
+
+type EventPresentationSource = Pick<
+  Event,
+  | 'startDate'
+  | 'event_status'
+  | 'eventStatus'
+  | 'bookings_enabled'
+  | 'booking_cutoff_at'
+>
+
+export function getEventPhase(event: EventPresentationSource, now: number = Date.now()): EventPhase {
+  if (normalizeEventStatus(event) === 'cancelled') return 'cancelled'
+  if (isEventInPast(event, now)) return 'ended'
+  return 'upcoming'
+}
+
+export function getEventPresentation(
+  event: EventPresentationSource,
+  now: number = Date.now()
+): EventPresentation {
+  const phase = getEventPhase(event, now)
+  const hasEnded = isEventInPast(event, now)
+  const isUpcoming = phase === 'upcoming'
+
+  // A blocked or cutoff-closed upcoming event still shows its policy and FAQs,
+  // because the visitor may yet book by phone. An ended or cancelled event
+  // shows neither.
+  const bookingBlocked =
+    Boolean(getEventBookingBlockReason(event, now)) || isEventBookingClosed(event, now)
+
+  return {
+    phase,
+    hasEnded,
+    showBookingForm: isUpcoming && !bookingBlocked,
+    showBookingPolicy: isUpcoming,
+    showBookingFaqs: isUpcoming,
+    showBookingCtaBand: isUpcoming,
+    showShareButton: isUpcoming,
+    // "Cancelled" is worth showing. "Scheduled" on a night that already
+    // happened reads as though it is still going ahead.
+    showStatusRow: phase !== 'ended',
+    factsVariant: isUpcoming ? 'live' : 'historic',
+    includeSchemaOffers: isUpcoming
+  }
+}

--- a/lib/event-seo-strategy.ts
+++ b/lib/event-seo-strategy.ts
@@ -1,8 +1,47 @@
 import type { Event } from '@/lib/api/events'
 import { normalizeEventStatus, isEventInPast } from '@/lib/event-lifecycle'
 
-export const PAST_EVENT_REDIRECT_DAYS = 30
+/**
+ * How long a past event counts as "recent" for presentation purposes: the
+ * /whats-on recent archive, and the wording on the event page itself.
+ *
+ * This is NOT an indexability threshold. Past events stay indexed indefinitely.
+ * It was previously named PAST_EVENT_REDIRECT_DAYS, when crossing it retired
+ * the page.
+ *
+ * Single source of truth: lib/api/events.ts imports this rather than declaring
+ * its own 30, so the listing window and the page wording cannot drift apart.
+ */
+export const RECENT_EVENT_WINDOW_DAYS = 30
 export const CANCELLED_INDEX_DAYS = 7
+
+/**
+ * Formats the SSOT says are discontinued and must not be promoted.
+ *
+ * Keeping past events indexed is good for formats that still run: each night
+ * adds to what the site can rank for. It is not good for a format that has
+ * stopped, because the page can start ranking and bring people in for
+ * something they cannot come to.
+ *
+ * docs/SSOT.md §"Nikki's Games Night": "Do not promote Nikki hosted/games
+ * nights as a recurring format. Nikki currently hosts Music Bingo only."
+ *
+ * Open mic is the other retired format, handled separately by isRetiredEvent()
+ * because it has a genuine replacement page and 301s to /live-music. A games
+ * night has no equivalent, so the page stays live for anyone with the link and
+ * is simply kept out of search (policy case E).
+ */
+const DISCONTINUED_FORMAT_TOKENS = ['games night']
+
+export function isDiscontinuedFormatEvent(
+  event: Partial<Pick<Event, 'name' | 'slug'>>
+): boolean {
+  const haystack = `${event.name ?? ''} ${event.slug ?? ''}`
+    .toLowerCase()
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+  return DISCONTINUED_FORMAT_TOKENS.some((token) => haystack.includes(token))
+}
 
 /**
  * Map category slugs to their actual top-level page routes.
@@ -24,45 +63,62 @@ export function getCategoryPageUrl(categorySlug: string | undefined | null): str
 export interface EventSeoStrategy {
   /** Whether the page should be indexed by search engines */
   index: boolean
-  /** If set, 301 redirect to this URL instead of rendering the page */
-  redirect?: string
   /** Whether to show the "event ended" banner */
   showEndedBanner: boolean
-  /** Stage: active, recent, stale */
-  stage: 'active' | 'recent' | 'stale'
+  /**
+   * Presentation stage only. `archived` does not mean retired: the page is
+   * still live and still indexed.
+   */
+  stage: 'active' | 'recent' | 'archived'
 }
 
 /**
  * Determine the SEO strategy for an event page based on its lifecycle stage.
  *
- * A stale event redirects to its permanent category page, never to the next
- * dated event. Pointing July's music bingo at September's looks like case A
- * (a close replacement) but the destination moves every month: Google
- * consolidates signals onto September's URL, which next month points somewhere
- * else again. A permanent redirect whose target keeps changing never settles.
- * The category page is the stable equivalent, and is exactly the example the
- * URL lifecycle policy gives for case B ("retired event -> category page").
+ * Past events are kept live and indexed indefinitely. An event page is only
+ * live for a couple of months before the night itself, which is not long
+ * enough to earn rankings; retiring it at 30 days threw that away every month
+ * and the category page had to start from scratch each time. Keeping the URL
+ * lets each night accumulate, and the pages are not near-duplicates: every
+ * night carries its own theme, name and highlights.
+ *
+ * The route into the next date is an on-page link, not a redirect. A redirect
+ * would delete the very content this policy exists to keep.
+ *
+ * Cancelled events are the one exception. Nothing happened on the night, so
+ * there is no content worth ranking, and they drop out after
+ * CANCELLED_INDEX_DAYS.
  *
  * @param event - The event to evaluate
  */
 export function getEventSeoStrategy(
-  event: Pick<Event, 'startDate' | 'event_status' | 'eventStatus' | 'category'>
+  event: Pick<Event, 'startDate' | 'event_status' | 'eventStatus' | 'category'> &
+    Partial<Pick<Event, 'name' | 'slug'>>
 ): EventSeoStrategy {
   const status = normalizeEventStatus(event)
   const isPast = isEventInPast(event)
 
-  // Cancelled events: index for 7 days, then noindex.
-  // Note: cancelled events never redirect, the page renders with a cancelled banner.
+  // Discontinued formats stay reachable but out of search, whatever their date.
+  // Keeping them indexed would rank a night nobody can attend.
+  if (isDiscontinuedFormatEvent(event)) {
+    return {
+      index: false,
+      showEndedBanner: isPast,
+      stage: isPast ? 'archived' : 'active',
+    }
+  }
+
+  // Cancelled events: index for 7 days, then noindex. Never redirect, the page
+  // renders with a cancelled banner.
   if (status === 'cancelled') {
     // We can't reliably know when it was cancelled from the event data,
     // so use the event date as proxy, noindex if event date was >7 days ago.
-    // Threshold uses `>` to align with generateMetadata() and app/sitemap.ts.
     const eventDate = Date.parse(event.startDate)
     const daysSinceEvent = (Date.now() - eventDate) / (1000 * 60 * 60 * 24)
     return {
       index: daysSinceEvent <= CANCELLED_INDEX_DAYS,
       showEndedBanner: true,
-      stage: 'stale',
+      stage: 'archived',
     }
   }
 
@@ -71,24 +127,15 @@ export function getEventSeoStrategy(
     return { index: true, showEndedBanner: false, stage: 'active' }
   }
 
-  // Recently past (0-30 days). Threshold uses `<=` to align with
-  // generateMetadata() and app/sitemap.ts which both use `>`.
+  // Past events stay indexed. `recent` vs `archived` only changes presentation
+  // and how prominently the page is surfaced in listings, never indexability.
   const eventDate = Date.parse(event.startDate)
   const daysSinceEvent = (Date.now() - eventDate) / (1000 * 60 * 60 * 24)
 
-  if (daysSinceEvent <= PAST_EVENT_REDIRECT_DAYS) {
-    return { index: true, showEndedBanner: true, stage: 'recent' }
-  }
-
-  // Stale past (30+ days): 301 to the permanent category page, or /whats-on
-  // when the event has no category. Unconditional, so the destination is
-  // deterministic and stable rather than depending on what happens to be
-  // scheduled next.
   return {
-    index: false,
-    redirect: getCategoryPageUrl(event.category?.slug),
+    index: true,
     showEndedBanner: true,
-    stage: 'stale',
+    stage: daysSinceEvent <= RECENT_EVENT_WINDOW_DAYS ? 'recent' : 'archived',
   }
 }
 

--- a/lib/event-seo-strategy.ts
+++ b/lib/event-seo-strategy.ts
@@ -31,16 +31,53 @@ export const CANCELLED_INDEX_DAYS = 7
  * night has no equivalent, so the page stays live for anyone with the link and
  * is simply kept out of search (policy case E).
  */
-const DISCONTINUED_FORMAT_TOKENS = ['games night']
+const DISCONTINUED_FORMATS: ReadonlyArray<{
+  token: string
+  /** Where to send anyone who lands on the page anyway. */
+  replacement: string
+  replacementLabel: string
+  /** Must be supportable by docs/SSOT.md, it is customer-facing copy. */
+  replacementCopy: string
+}> = [
+  {
+    token: 'games night',
+    replacement: '/music-bingo',
+    replacementLabel: 'See Music Bingo dates',
+    // SSOT: "Nikki currently hosts Music Bingo only."
+    replacementCopy: 'This night is no longer running. Nikki hosts Music Bingo now.',
+  },
+]
+
+function discontinuedHaystack(event: Partial<Pick<Event, 'name' | 'slug'>>): string {
+  return `${event.name ?? ''} ${event.slug ?? ''}`
+    .toLowerCase()
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+}
 
 export function isDiscontinuedFormatEvent(
   event: Partial<Pick<Event, 'name' | 'slug'>>
 ): boolean {
-  const haystack = `${event.name ?? ''} ${event.slug ?? ''}`
-    .toLowerCase()
-    .replace(/[-_]+/g, ' ')
-    .replace(/\s+/g, ' ')
-  return DISCONTINUED_FORMAT_TOKENS.some((token) => haystack.includes(token))
+  const haystack = discontinuedHaystack(event)
+  return DISCONTINUED_FORMATS.some((format) => haystack.includes(format.token))
+}
+
+/**
+ * Where a discontinued-format page should send its visitors, and what to call
+ * that link. Null when the event is not a discontinued format.
+ *
+ * The page has no useful category page of its own, so falling back to
+ * /whats-on would drop someone interested in a Nikki night onto a generic
+ * listing. Music Bingo is the format she actually hosts now.
+ */
+export function getDiscontinuedFormatReplacement(
+  event: Partial<Pick<Event, 'name' | 'slug'>>
+): { href: string; label: string; copy: string } | null {
+  const haystack = discontinuedHaystack(event)
+  const match = DISCONTINUED_FORMATS.find((format) => haystack.includes(format.token))
+  return match
+    ? { href: match.replacement, label: match.replacementLabel, copy: match.replacementCopy }
+    : null
 }
 
 /**

--- a/lib/event-seo-strategy.ts
+++ b/lib/event-seo-strategy.ts
@@ -35,13 +35,18 @@ export interface EventSeoStrategy {
 /**
  * Determine the SEO strategy for an event page based on its lifecycle stage.
  *
+ * A stale event redirects to its permanent category page, never to the next
+ * dated event. Pointing July's music bingo at September's looks like case A
+ * (a close replacement) but the destination moves every month: Google
+ * consolidates signals onto September's URL, which next month points somewhere
+ * else again. A permanent redirect whose target keeps changing never settles.
+ * The category page is the stable equivalent, and is exactly the example the
+ * URL lifecycle policy gives for case B ("retired event -> category page").
+ *
  * @param event - The event to evaluate
- * @param nextEventInCategory - The next upcoming event in the same category (if any).
- *   Must NOT be synthetic/fallback data. Pass null if lookup failed or returned fallback.
  */
 export function getEventSeoStrategy(
-  event: Pick<Event, 'startDate' | 'event_status' | 'eventStatus' | 'category'>,
-  nextEventInCategory: Pick<Event, 'slug' | 'id'> | null
+  event: Pick<Event, 'startDate' | 'event_status' | 'eventStatus' | 'category'>
 ): EventSeoStrategy {
   const status = normalizeEventStatus(event)
   const isPast = isEventInPast(event)
@@ -75,22 +80,16 @@ export function getEventSeoStrategy(
     return { index: true, showEndedBanner: true, stage: 'recent' }
   }
 
-  // Stale past (30+ days), redirect if we have a next event, noindex otherwise
-  if (nextEventInCategory) {
-    const segment = nextEventInCategory.slug || nextEventInCategory.id
-    return {
-      index: false,
-      redirect: `/events/${segment}`,
-      showEndedBanner: true,
-      stage: 'stale',
-    }
+  // Stale past (30+ days): 301 to the permanent category page, or /whats-on
+  // when the event has no category. Unconditional, so the destination is
+  // deterministic and stable rather than depending on what happens to be
+  // scheduled next.
+  return {
+    index: false,
+    redirect: getCategoryPageUrl(event.category?.slug),
+    showEndedBanner: true,
+    stage: 'stale',
   }
-
-  // Stale past, no next event, noindex but keep the page visible so users
-  // who arrive from event listings can still see event details and book future events.
-  // Category pages (/quiz-night, /music-bingo etc.) are standalone SEO assets and
-  // should not receive redirects from individual event pages.
-  return { index: false, showEndedBanner: true, stage: 'stale' }
 }
 
 /**
@@ -127,11 +126,3 @@ export function getSchemaOfferAvailability(
   }
 }
 
-/**
- * Check if an event appears to be synthetic/fallback data from the API client.
- * Returns true if the event should NOT be trusted for redirect decisions.
- */
-export function isFallbackEvent(event: Pick<Event, 'id' | 'name'>): boolean {
-  // The API client generates fallback events with specific markers
-  return !event.id || event.id === 'fallback' || event.name === 'Upcoming Event'
-}

--- a/lib/event-url.ts
+++ b/lib/event-url.ts
@@ -2,6 +2,7 @@ import type { Event } from '@/lib/api'
 
 const WEBSITE_ORIGIN = 'https://www.the-anchor.pub'
 const EVENT_PATH_PREFIX = '/events'
+const EVENTS_LISTING_PATH = '/whats-on'
 
 type EventUrlSource = Pick<Event, 'slug' | 'id' | 'url'>
 
@@ -47,10 +48,13 @@ export function getEventWebsitePath(event: EventUrlSource): string {
     if (resolved.startsWith('/events/') && resolved.length > '/events/'.length) {
       return resolved
     }
-    // Fall through to default /events listing page
+    // Fall through to the events listing below
   }
 
-  return EVENT_PATH_PREFIX
+  // There is no /events index route, so it returns 404. An event with no slug,
+  // no id and no usable url has nothing to link to; send visitors to the
+  // listing page that does exist.
+  return EVENTS_LISTING_PATH
 }
 
 export function getEventWebsiteUrl(event: EventUrlSource, options?: { absolute?: boolean }): string {

--- a/lib/structured-data/event-schema.ts
+++ b/lib/structured-data/event-schema.ts
@@ -3,6 +3,7 @@ import { getEventDateRangeUtc } from '@/lib/event-calendar'
 import { DEFAULT_EVENT_IMAGE } from '@/lib/image-fallbacks'
 import { getEventWebsiteUrl } from '@/lib/event-url'
 import { getSchemaEventStatus, getSchemaOfferAvailability, CATEGORY_ROUTES } from '@/lib/event-seo-strategy'
+import { getEventPresentation } from '@/lib/event-presentation'
 
 
 const SITE_ORIGIN = 'https://www.the-anchor.pub'
@@ -72,6 +73,14 @@ function sanitiseMainEntityOfPage(
 }
 
 export function buildEventSchema(event: Event) {
+  // Same resolver the page uses, so the markup cannot advertise tickets for a
+  // night the page itself says has ended. schema.org has no "completed" event
+  // status (the enumeration is Scheduled / Cancelled / Postponed / Rescheduled
+  // / MovedOnline), so `startDate` in the past is what tells a crawler the
+  // event is over. What must not happen is pairing that past date with a live
+  // offer, a reserve action or remaining capacity.
+  const presentation = getEventPresentation(event)
+  const isBookable = presentation.includeSchemaOffers
   const eventUrl = getEventWebsiteUrl(event, { absolute: true })
   const eventImage = event.image?.[0] || event.heroImageUrl || event.thumbnailImageUrl || DEFAULT_EVENT_IMAGE
   const bookingUrl =
@@ -177,7 +186,7 @@ export function buildEventSchema(event: Event) {
           name: 'The Anchor Entertainment',
           url: 'https://www.the-anchor.pub'
         },
-    offers,
+    ...(isBookable && { offers }),
     image: Array.isArray(event.image) && event.image.length > 0 ? event.image : [eventImage],
     ...(event.thumbnailImageUrl && { thumbnailUrl: event.thumbnailImageUrl }),
     organizer:
@@ -190,22 +199,25 @@ export function buildEventSchema(event: Event) {
     ...(event.maximumAttendeeCapacity && {
       maximumAttendeeCapacity: event.maximumAttendeeCapacity
     }),
-    ...(event.remainingAttendeeCapacity !== undefined && {
-      remainingAttendeeCapacity: event.remainingAttendeeCapacity
-    }),
+    ...(isBookable &&
+      event.remainingAttendeeCapacity !== undefined && {
+        remainingAttendeeCapacity: event.remainingAttendeeCapacity
+      }),
     url: eventUrl,
     ...(event.mainEntityOfPage && { mainEntityOfPage: sanitiseMainEntityOfPage(event.mainEntityOfPage, eventUrl) }),
-    potentialAction: sanitisePotentialAction(event.potentialAction) ?? {
-      '@type': 'ReserveAction',
-      target: {
-        '@type': 'EntryPoint',
-        urlTemplate: eventUrl,
-        actionPlatform: [
-          'https://schema.org/DesktopWebPlatform',
-          'https://schema.org/MobileWebPlatform'
-        ]
+    ...(isBookable && {
+      potentialAction: sanitisePotentialAction(event.potentialAction) ?? {
+        '@type': 'ReserveAction',
+        target: {
+          '@type': 'EntryPoint',
+          urlTemplate: eventUrl,
+          actionPlatform: [
+            'https://schema.org/DesktopWebPlatform',
+            'https://schema.org/MobileWebPlatform'
+          ]
+        }
       }
-    },
+    }),
     ...(event.highlights && event.highlights.length > 0 && {
       subjectOf: {
         '@type': 'CreativeWork',

--- a/tasks/event-permanent-page-enrichment.md
+++ b/tasks/event-permanent-page-enrichment.md
@@ -34,26 +34,56 @@ evidence onto five permanent pages, not in maintaining hundreds of thin ones.
 
 So the data model needs nothing new. This is a display and aggregation job.
 
-## Open question to resolve first
+## API feasibility: resolved 2026-08-06
 
-**How much event history does the management API actually return?**
+Checked against the live management API server-side. All good:
 
-`app/api/events/route.ts` (the public proxy) appears to return upcoming events
-only: a local call with `from_date=2025-01-01` returned just the two upcoming
-events. The server-side client does better, since `app/sitemap.ts` calls
-`anchorAPI.getEvents({ from_date: '2000-01-01' })` and the live sitemap has
-included past dates. What is not known is whether the API returns months of
-history or only a short tail.
+- **16 months of history available.** 58 past events, oldest 2025-03-28.
+- **`category_id` filters past events fine.** One call with
+  `category_id=<id>&from_date=2000-01-01` returned 6 past music bingo nights
+  (Feb, Mar, Apr, May, Jun, Jul 2026). No management-app change needed for the
+  fetch.
+- **The public `/api/events` proxy returns upcoming events only.** Use the
+  server-side `anchorAPI` client, as `app/sitemap.ts` does, not the proxy.
+- **The list endpoint returns a lightweight projection.** `category`,
+  `short_description`, `long_description`, `performer_name` and the hero image
+  fields all come back null there even when set. `highlights` and `image` do
+  come through. If the block needs anything beyond those, it needs a per-event
+  detail fetch.
 
-Check this before designing anything else. Roughly:
+## Blocker: the source fields cannot be filled in
 
-```
-anchorAPI.getEvents({ from_date: '2025-01-01', status: 'scheduled', limit: 100 })
-```
+`previous_event_summary` and `attendance_note` **have no input anywhere in the
+management app.** Verified 2026-08-06:
 
-called server-side, then count how many results predate today. If the answer is
-"only a few weeks", this task needs a management-app change first and should be
-re-scoped.
+- The columns exist (added by
+  `supabase/migrations/20260528000000_event_seo_keyword_engine.sql`, 28 May 2026).
+- `src/services/events.ts` validates them (300 and 200 char limits).
+- `src/app/actions/events.ts:321-322` would save them if the form posted them.
+- `src/app/api/events/route.ts:188-189` serves them to this website.
+- **Zero `.tsx` files reference either field.** No textarea, no label, nothing.
+- **0 of 58 past events have either populated**, which follows.
+
+The columns were created by the SEO keyword engine migration and the form input
+was never built. So the question is not "will staff keep these filled in", it is
+"someone has to build the field first", and that work is in
+`OJ-AnchorManagementTools`, not here.
+
+## What is actually populated on past events today
+
+| Field | Populated |
+|---|---|
+| `highlights` | 46 / 58 |
+| `image` | set on the sample checked |
+| `image_alt_text` | 17 / 58 |
+| `previous_event_summary` | 0 / 58 |
+| `attendance_note` | 0 / 58 |
+| `performer_name` | 0 / 58 (null in the list projection) |
+
+This supports a **reduced version buildable today with no management-app
+change**: poster, date and `highlights` from the last three nights in the
+category. It is weaker evidence than a written recap, but it is real, it is
+already there, and it needs no new staff habit.
 
 ## Proposed work
 
@@ -85,18 +115,21 @@ re-scoped.
 - **Event images are square.** Use `aspect-square` containers.
 - **Prices are live from the DB**, never hardcoded, if any price is shown.
 
-## Dependency on staff behaviour
+## Two ways to sequence this
 
-This only works if `previous_event_summary` and `attendance_note` are actually
-filled in after each event in the management app. Today they are populated
-inconsistently. Two options, in preference order:
+**Option A, ship the reduced version now.** Poster, date and `highlights` from
+the last three nights in the category. No management-app change, no new staff
+habit, works with today's data. Weaker than a written recap but real.
 
-1. Make them a prompt in the management app's post-event flow. Better, because
-   the content then exists for both layers.
-2. Accept partial coverage and let the block render from whatever exists.
+**Option B, build the management-app field first.** Add
+`previous_event_summary` and `attendance_note` textareas to the event form in
+`OJ-AnchorManagementTools`. The server action, validation and API already
+handle them, so it is genuinely just the form input plus a place to put it.
+Then this task renders the fuller block. Needs staff to write a line after each
+event, so it only pays off if that becomes habit.
 
-If neither happens, this task produces an empty component and should not be
-built.
+A and B compose: build A, and the component picks up recap text later if B ever
+lands. Recommend A first.
 
 ## Explicitly out of scope
 

--- a/tasks/event-permanent-page-enrichment.md
+++ b/tasks/event-permanent-page-enrichment.md
@@ -1,0 +1,107 @@
+# Scope: feed past-event evidence into the permanent event pages
+
+**Status:** scoped, not started
+**Created:** 2026-08-06
+**Depends on:** `fix/event-ended-state` (steps 1 to 4) being live
+**Complexity:** 3 (M). Four to six files, one new API call, no schema changes.
+
+---
+
+## Why
+
+The permanent pages (`/music-bingo`, `/quiz-night`, `/cash-bingo`, `/karaoke`,
+`/live-music`) are the layer meant to accumulate authority. They currently show
+only upcoming dates and hand-written FAQs. Every month's proof that the night is
+established and well attended is captured on the dated event page and then
+thrown away when that page redirects at 30 days.
+
+This is the one item in this workstream with lasting SEO upside. It is also the
+reason not to build a per-event archive: the value is in consolidating the
+evidence onto five permanent pages, not in maintaining hundreds of thin ones.
+
+## What already exists
+
+`Event` (see `lib/api/events.ts`) already carries the fields:
+
+| Field | Line | Currently used |
+|---|---|---|
+| `previous_event_summary` | 137 | Dated event page sidebar only |
+| `attendance_note` | 138 | Dated event page sidebar only |
+| `highlights` | 37 | Both dated and permanent pages |
+| `image` / `heroImageUrl` | - | Dated page hero, event cards |
+| `performer` / `performer_name` | 122 | Dated page details list |
+| `video` | 82 | Dated page |
+
+So the data model needs nothing new. This is a display and aggregation job.
+
+## Open question to resolve first
+
+**How much event history does the management API actually return?**
+
+`app/api/events/route.ts` (the public proxy) appears to return upcoming events
+only: a local call with `from_date=2025-01-01` returned just the two upcoming
+events. The server-side client does better, since `app/sitemap.ts` calls
+`anchorAPI.getEvents({ from_date: '2000-01-01' })` and the live sitemap has
+included past dates. What is not known is whether the API returns months of
+history or only a short tail.
+
+Check this before designing anything else. Roughly:
+
+```
+anchorAPI.getEvents({ from_date: '2025-01-01', status: 'scheduled', limit: 100 })
+```
+
+called server-side, then count how many results predate today. If the answer is
+"only a few weeks", this task needs a management-app change first and should be
+re-scoped.
+
+## Proposed work
+
+1. **`getPastEventsByCategory(categoryId, limit, withinDays)`** in
+   `lib/api/events.ts`, mirroring the existing `getUpcomingEventsByCategory`.
+   Must filter out drafts and retired events the same way.
+
+2. **`<PreviousNights />`** component in `components/events/`. Renders, from the
+   most recent past events in a category:
+   - two or three square posters (event images are 1:1, never crop them)
+   - `previous_event_summary` as a short quote-style line
+   - `attendance_note` where present
+   - the host or performer name where consistent across events
+
+3. **Wire into the five permanent pages.** Place it below the upcoming-dates
+   section and above the FAQs, so the page reads: what it is, when it is next,
+   proof it is a going concern, questions.
+
+4. **Empty state.** If there are no usable past events, render nothing. Do not
+   render a heading with an empty body, and do not invent copy.
+
+## Constraints
+
+- **SSOT applies.** Any claim rendered here comes from the management DB. Do not
+  write summary copy in the codebase. If `previous_event_summary` is empty, the
+  block is empty. See `docs/SSOT.md`.
+- **No review or rating markup.** Attendance evidence is body content, not
+  structured data. Self-serving review schema is out.
+- **Event images are square.** Use `aspect-square` containers.
+- **Prices are live from the DB**, never hardcoded, if any price is shown.
+
+## Dependency on staff behaviour
+
+This only works if `previous_event_summary` and `attendance_note` are actually
+filled in after each event in the management app. Today they are populated
+inconsistently. Two options, in preference order:
+
+1. Make them a prompt in the management app's post-event flow. Better, because
+   the content then exists for both layers.
+2. Accept partial coverage and let the block render from whatever exists.
+
+If neither happens, this task produces an empty component and should not be
+built.
+
+## Explicitly out of scope
+
+- A per-event archive with recaps and photo galleries on every dated event page.
+  The site has roughly five live event URLs at any time; per-event archive
+  content is ongoing cost against near-zero return at that scale.
+- Keeping stale event pages live instead of redirecting them. Settled in
+  `tasks/gsc-indexing-fix/url-lifecycle-policy.md` §1.

--- a/tasks/gsc-indexing-fix/url-lifecycle-policy.md
+++ b/tasks/gsc-indexing-fix/url-lifecycle-policy.md
@@ -55,34 +55,51 @@ Driven by `lib/event-seo-strategy.ts` (function `getEventSeoStrategy`). Behaviou
 | Active (future, not cancelled) | Render, indexable, no banner. | Default branch in `getEventSeoStrategy`. |
 | Cancelled, ≤ 7 days since event date | Render with cancelled banner, indexable. | `CANCELLED_INDEX_DAYS = 7`. |
 | Cancelled, > 7 days since event date | Render with cancelled banner, `noindex`. (E) | Same. |
-| Recent past (≤ 30 days), not cancelled | Render with "ended" banner, still indexable, every booking surface off. | `PAST_EVENT_REDIRECT_DAYS = 30`, plus `getEventPresentation`. |
-| Stale past (> 30 days) | 301 to the permanent category page (`/music-bingo`, `/quiz-night`, `/cash-bingo`, `/karaoke`, `/live-music`), or `/whats-on` when the event has no mapped category. (B) | `getCategoryPageUrl(event.category?.slug)` inside `getEventSeoStrategy`; `permanentRedirect` in `app/events/[id]/page.tsx`. |
+| Past, not cancelled, **any age** | Render with "ended" banner, **indexable, kept indefinitely, never redirected**, every booking surface off, prominent link to the next date in the category. | `getEventSeoStrategy` returns `index: true` for all past events; `getEventPresentation` switches the booking surfaces off; `nextInCategory` in `app/events/[id]/page.tsx` builds the link. |
+| Past, ≤ 30 days vs > 30 days | Presentation only (`stage: 'recent'` vs `'archived'`). Controls the /whats-on recent archive and page wording. **Never indexability.** | `RECENT_EVENT_WINDOW_DAYS = 30`, also imported by `lib/api/events.ts` so the listing window cannot drift. |
 | Draft (`event_status === 'draft'`) | 301 to `/whats-on`. (B) | `app/events/[id]/page.tsx`. |
 | API returns 404 / fetch throws | 301 to `/whats-on`. (B) | `app/events/[id]/page.tsx`. |
 | Slug differs from canonical segment | 301 to canonical segment. (A) | `getEventCanonicalSegment` check. |
 
-**Rationale for redirecting stale events to the category page, not the next event (changed 2026-08-06)**
+**Rationale for keeping past events live and indexed (owner decision, 2026-08-06)**
 
-Until August 2026 a stale event 301'd to the next upcoming event in the same
-category, and the code carried a comment saying category pages "should not
-receive redirects from individual event pages". Both were wrong.
+Past events used to retire at 30 days: `noindex` plus a 301 to the next event
+in the category. That is now removed. Past event pages stay live, stay indexed,
+and are never redirected, at any age.
 
-The destination moved every month. July's music bingo pointed at September's,
-and once September's went stale it pointed at November's. At any single moment
-that is one hop, so the `redirect-loops` test never caught it, but a permanent
-redirect whose target keeps changing never lets Google consolidate anything:
-signals land on a URL that is itself about to be retired.
+The reason is dwell time, not tidiness. An event page goes up a few weeks
+before the night and used to be gone 30 days after it, so it was live for
+roughly two months total. That is not long enough for a page to earn rankings.
+Every month the site threw away the page it had just built and the category
+page started from scratch again. Keeping the URL lets each night accumulate.
 
-The category page is the stable topical equivalent, and case B in the matrix
-above already gives "retired event → category page" as its worked example. The
-worry about category pages receiving redirects was unfounded. Receiving a
-topically-matched 301 does not harm a destination page. The soft-404 risk
-Google warns about applies to mass redirects to an irrelevant destination, such
-as everything to `/`, not to a music bingo night redirecting to the music bingo
-hub.
+The usual objection is thin or duplicate content across many near-identical
+event pages. Checked against the live data before making this change, and it
+does not apply here: the six past Music Bingo nights carry six distinct names,
+themes and highlight sets ("Cowboys & Queens Country Music Bingo" and so on).
+They are genuinely different pages, not a template repeated.
 
-Redirecting is now unconditional at 30 days, so behaviour is deterministic and
-no per-request lookup of "what is on next" is needed.
+Two things make this safe, and both must stay true:
+
+1. **An ended page must not look like a live sales page.** `getEventPresentation`
+   switches off the booking form, the booking policy card, booking FAQs, the
+   "Ready to book" CTA, the share button and the status row, and flips the
+   facts strip to past tense. A page that is indexed forever and still says
+   "Book now" for a night in 2026 is worse than no page.
+2. **Its markup must not advertise tickets.** `buildEventSchema` omits `offers`,
+   `potentialAction` and `remainingAttendeeCapacity` once an event is over.
+
+**Routing visitors to the next date is an on-page link, never a redirect.** A
+redirect would delete the content this policy exists to keep. Past event pages
+carry the next date in the ended banner and in the closing CTA, plus links to
+the permanent category page and `/whats-on`.
+
+Past events are also listed in `sitemap.xml`. Excluding them would slow how
+often Google recrawls the pages this policy exists to let accumulate.
+
+Cancelled events are the one exception and still drop out after
+`CANCELLED_INDEX_DAYS`. Nothing happened on the night, so there is no content
+worth ranking.
 
 **Rationale for blanket 301 → /whats-on on draft / missing events**
 

--- a/tasks/gsc-indexing-fix/url-lifecycle-policy.md
+++ b/tasks/gsc-indexing-fix/url-lifecycle-policy.md
@@ -2,7 +2,7 @@
 
 **Owner:** SEO + Engineering, The Anchor website (`OJ-The-Anchor.pub`)
 **Audience:** any developer changing routes, redirects, event lifecycle, blog tags, or one-off pages.
-**Last reviewed:** 2026-04-30
+**Last reviewed:** 2026-08-06
 
 This document codifies how URLs are retired on this site. It exists because GSC
 "Redirect error", "Page with redirect", and "Crawled - currently not indexed"
@@ -55,12 +55,34 @@ Driven by `lib/event-seo-strategy.ts` (function `getEventSeoStrategy`). Behaviou
 | Active (future, not cancelled) | Render, indexable, no banner. | Default branch in `getEventSeoStrategy`. |
 | Cancelled, ≤ 7 days since event date | Render with cancelled banner, indexable. | `CANCELLED_INDEX_DAYS = 7`. |
 | Cancelled, > 7 days since event date | Render with cancelled banner, `noindex`. (E) | Same. |
-| Recent past (≤ 30 days), not cancelled | Render with "ended" banner, still indexable. | `PAST_EVENT_REDIRECT_DAYS = 30`. |
-| Stale past (> 30 days), next event in same category | 301 to next event in category. (A) | `permanentRedirect(seoStrategy.redirect)` in `app/events/[id]/page.tsx`. |
-| Stale past (> 30 days), no next event in category | Render with "ended" banner, `noindex`. (E) | Page stays visible to anyone arriving from a deep link or stale category landing. |
+| Recent past (≤ 30 days), not cancelled | Render with "ended" banner, still indexable, every booking surface off. | `PAST_EVENT_REDIRECT_DAYS = 30`, plus `getEventPresentation`. |
+| Stale past (> 30 days) | 301 to the permanent category page (`/music-bingo`, `/quiz-night`, `/cash-bingo`, `/karaoke`, `/live-music`), or `/whats-on` when the event has no mapped category. (B) | `getCategoryPageUrl(event.category?.slug)` inside `getEventSeoStrategy`; `permanentRedirect` in `app/events/[id]/page.tsx`. |
 | Draft (`event_status === 'draft'`) | 301 to `/whats-on`. (B) | `app/events/[id]/page.tsx`. |
 | API returns 404 / fetch throws | 301 to `/whats-on`. (B) | `app/events/[id]/page.tsx`. |
 | Slug differs from canonical segment | 301 to canonical segment. (A) | `getEventCanonicalSegment` check. |
+
+**Rationale for redirecting stale events to the category page, not the next event (changed 2026-08-06)**
+
+Until August 2026 a stale event 301'd to the next upcoming event in the same
+category, and the code carried a comment saying category pages "should not
+receive redirects from individual event pages". Both were wrong.
+
+The destination moved every month. July's music bingo pointed at September's,
+and once September's went stale it pointed at November's. At any single moment
+that is one hop, so the `redirect-loops` test never caught it, but a permanent
+redirect whose target keeps changing never lets Google consolidate anything:
+signals land on a URL that is itself about to be retired.
+
+The category page is the stable topical equivalent, and case B in the matrix
+above already gives "retired event → category page" as its worked example. The
+worry about category pages receiving redirects was unfounded. Receiving a
+topically-matched 301 does not harm a destination page. The soft-404 risk
+Google warns about applies to mass redirects to an irrelevant destination, such
+as everything to `/`, not to a music bingo night redirecting to the music bingo
+hub.
+
+Redirecting is now unconditional at 30 days, so behaviour is deterministic and
+no per-request lookup of "what is on next" is needed.
 
 **Rationale for blanket 301 → /whats-on on draft / missing events**
 

--- a/tests/event-presentation.test.ts
+++ b/tests/event-presentation.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Event presentation resolver tests.
+ *
+ * These lock in the rule that every booking-related surface on an event page
+ * is switched off once the event is over, and that the JSON-LD agrees with the
+ * visible page. The bug this prevents: `/events/music-bingo-2026-07-17` showed
+ * "This event has ended" to visitors while emitting
+ * `offers.availability: InStock` to search engines, and still rendered a
+ * booking policy card, booking FAQs, a "Ready to book" CTA and a
+ * "Status: Scheduled" row.
+ */
+
+import { getEventPhase, getEventPresentation } from '@/lib/event-presentation'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+const FIXED_NOW = Date.UTC(2026, 4, 1, 12, 0, 0) // 2026-05-01T12:00:00Z
+
+function isoDaysAgo(days: number): string {
+  return new Date(FIXED_NOW - days * ONE_DAY_MS).toISOString()
+}
+
+function isoDaysFromNow(days: number): string {
+  return new Date(FIXED_NOW + days * ONE_DAY_MS).toISOString()
+}
+
+const UPCOMING = { startDate: isoDaysFromNow(7), event_status: 'scheduled', eventStatus: 'scheduled' }
+const ENDED = { startDate: isoDaysAgo(20), event_status: 'scheduled', eventStatus: 'scheduled' }
+const CANCELLED_FUTURE = { startDate: isoDaysFromNow(3), event_status: 'cancelled', eventStatus: 'cancelled' }
+const CANCELLED_PAST = { startDate: isoDaysAgo(3), event_status: 'cancelled', eventStatus: 'cancelled' }
+
+describe('getEventPhase', () => {
+  it('classifies a future scheduled event as upcoming', () => {
+    expect(getEventPhase(UPCOMING, FIXED_NOW)).toBe('upcoming')
+  })
+
+  it('classifies a past scheduled event as ended', () => {
+    expect(getEventPhase(ENDED, FIXED_NOW)).toBe('ended')
+  })
+
+  it('classifies a cancelled event as cancelled regardless of date', () => {
+    expect(getEventPhase(CANCELLED_FUTURE, FIXED_NOW)).toBe('cancelled')
+    expect(getEventPhase(CANCELLED_PAST, FIXED_NOW)).toBe('cancelled')
+  })
+
+  it('treats a sold out future event as still upcoming', () => {
+    const soldOut = { startDate: isoDaysFromNow(2), event_status: 'sold_out', eventStatus: 'sold_out' }
+    expect(getEventPhase(soldOut, FIXED_NOW)).toBe('upcoming')
+  })
+})
+
+describe('getEventPresentation, ended events', () => {
+  const presentation = getEventPresentation(ENDED, FIXED_NOW)
+
+  it('switches off every booking surface', () => {
+    expect(presentation.showBookingForm).toBe(false)
+    expect(presentation.showBookingPolicy).toBe(false)
+    expect(presentation.showBookingFaqs).toBe(false)
+    expect(presentation.showBookingCtaBand).toBe(false)
+    expect(presentation.showShareButton).toBe(false)
+  })
+
+  it('hides the "Status: Scheduled" row so the page cannot read as still going ahead', () => {
+    expect(presentation.showStatusRow).toBe(false)
+  })
+
+  it('presents the facts strip as a historical record', () => {
+    expect(presentation.factsVariant).toBe('historic')
+  })
+
+  it('omits offers from the JSON-LD so schema cannot contradict the page', () => {
+    expect(presentation.includeSchemaOffers).toBe(false)
+  })
+
+  it('reports hasEnded', () => {
+    expect(presentation.hasEnded).toBe(true)
+  })
+})
+
+describe('getEventPresentation, upcoming events', () => {
+  const presentation = getEventPresentation(UPCOMING, FIXED_NOW)
+
+  it('shows the full booking experience', () => {
+    expect(presentation).toMatchObject({
+      phase: 'upcoming',
+      hasEnded: false,
+      showBookingForm: true,
+      showBookingPolicy: true,
+      showBookingFaqs: true,
+      showBookingCtaBand: true,
+      showShareButton: true,
+      showStatusRow: true,
+      factsVariant: 'live',
+      includeSchemaOffers: true
+    })
+  })
+
+  it('hides only the form, not the policy, when bookings are disabled', () => {
+    const noBooking = { ...UPCOMING, bookings_enabled: false }
+    const result = getEventPresentation(noBooking, FIXED_NOW)
+    expect(result.showBookingForm).toBe(false)
+    // The visitor can still ring up, so the policy and FAQs stay useful.
+    expect(result.showBookingPolicy).toBe(true)
+    expect(result.showBookingFaqs).toBe(true)
+    expect(result.includeSchemaOffers).toBe(true)
+  })
+
+  it('hides the form once the online sales cutoff has passed', () => {
+    const cutoffPassed = { ...UPCOMING, booking_cutoff_at: isoDaysAgo(1) }
+    const result = getEventPresentation(cutoffPassed, FIXED_NOW)
+    expect(result.showBookingForm).toBe(false)
+    expect(result.showBookingPolicy).toBe(true)
+  })
+})
+
+describe('getEventPresentation, cancelled events', () => {
+  it('switches off booking surfaces but keeps the status row visible', () => {
+    const result = getEventPresentation(CANCELLED_FUTURE, FIXED_NOW)
+    expect(result.showBookingForm).toBe(false)
+    expect(result.showBookingPolicy).toBe(false)
+    expect(result.showBookingCtaBand).toBe(false)
+    expect(result.includeSchemaOffers).toBe(false)
+    // "Cancelled" is information the visitor needs.
+    expect(result.showStatusRow).toBe(true)
+  })
+
+  it('reports hasEnded only when the date has also passed', () => {
+    expect(getEventPresentation(CANCELLED_FUTURE, FIXED_NOW).hasEnded).toBe(false)
+    expect(getEventPresentation(CANCELLED_PAST, FIXED_NOW).hasEnded).toBe(true)
+  })
+})

--- a/tests/event-schema-lifecycle.test.ts
+++ b/tests/event-schema-lifecycle.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Event JSON-LD lifecycle tests.
+ *
+ * Regression guard for the live bug on /events/music-bingo-2026-07-17: the page
+ * displayed "This event has ended" while its markup emitted
+ * `offers.availability: InStock`, a ReserveAction and a `validFrom` stamped at
+ * request time. Markup that contradicts the visible page is the one failure
+ * mode here with real downside, so it is locked in with tests.
+ *
+ * Note: schema.org has no "completed" event status. The EventStatusType
+ * enumeration is Scheduled / Cancelled / Postponed / Rescheduled / MovedOnline.
+ * A past event correctly stays EventScheduled; what must go is the live offer.
+ */
+
+import { buildEventSchema } from '@/lib/structured-data/event-schema'
+import type { Event } from '@/lib/api'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+function buildEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'evt-1',
+    slug: 'music-bingo-test',
+    name: 'Music Bingo',
+    description: 'A music bingo night at The Anchor.',
+    startDate: new Date(Date.now() + 7 * ONE_DAY_MS).toISOString(),
+    event_status: 'scheduled',
+    eventStatus: 'scheduled',
+    remainingAttendeeCapacity: 24,
+    offers: {
+      '@type': 'Offer',
+      price: '5',
+      priceCurrency: 'GBP',
+      availability: 'https://schema.org/InStock',
+      validFrom: new Date().toISOString(),
+      url: 'https://www.the-anchor.pub/events/music-bingo-test'
+    },
+    ...overrides
+  } as Event
+}
+
+describe('buildEventSchema, upcoming events', () => {
+  const schema = buildEventSchema(buildEvent())
+
+  it('advertises the offer', () => {
+    expect(schema.offers).toBeDefined()
+    expect(schema.offers).toMatchObject({ availability: 'https://schema.org/InStock' })
+  })
+
+  it('includes a reserve action and remaining capacity', () => {
+    expect(schema.potentialAction).toBeDefined()
+    expect(schema.remainingAttendeeCapacity).toBe(24)
+  })
+
+  it('keeps eventStatus as scheduled', () => {
+    expect(schema.eventStatus).toBe('https://schema.org/EventScheduled')
+  })
+})
+
+describe('buildEventSchema, past events', () => {
+  const schema = buildEventSchema(
+    buildEvent({ startDate: new Date(Date.now() - 20 * ONE_DAY_MS).toISOString() })
+  )
+
+  it('omits offers entirely so nothing claims tickets are on sale', () => {
+    expect(schema.offers).toBeUndefined()
+  })
+
+  it('omits the reserve action', () => {
+    expect(schema.potentialAction).toBeUndefined()
+  })
+
+  it('omits remaining capacity, which would imply seats are still available', () => {
+    expect(schema.remainingAttendeeCapacity).toBeUndefined()
+  })
+
+  it('still describes the event, so the page remains valid Event markup', () => {
+    expect(schema['@type']).toBe('Event')
+    expect(schema.name).toBe('Music Bingo')
+    expect(schema.startDate).toBeDefined()
+    expect(schema.location).toBeDefined()
+  })
+
+  it('leaves eventStatus as scheduled, since schema.org has no completed status', () => {
+    expect(schema.eventStatus).toBe('https://schema.org/EventScheduled')
+  })
+})
+
+describe('buildEventSchema, cancelled events', () => {
+  const schema = buildEventSchema(
+    buildEvent({
+      startDate: new Date(Date.now() + 3 * ONE_DAY_MS).toISOString(),
+      event_status: 'cancelled',
+      eventStatus: 'cancelled'
+    })
+  )
+
+  it('marks the event cancelled and drops the offer', () => {
+    expect(schema.eventStatus).toBe('https://schema.org/EventCancelled')
+    expect(schema.offers).toBeUndefined()
+    expect(schema.potentialAction).toBeUndefined()
+  })
+})
+
+describe('buildEventSchema, multi-ticket past events', () => {
+  it('omits the per-ticket offer array too', () => {
+    const schema = buildEventSchema(
+      buildEvent({
+        startDate: new Date(Date.now() - 40 * ONE_DAY_MS).toISOString(),
+        ticket_types: [
+          { name: 'Standard', price: 5 },
+          { name: 'Premium', price: 12 }
+        ]
+      } as Partial<Event>)
+    )
+    expect(schema.offers).toBeUndefined()
+  })
+})

--- a/tests/event-seo-strategy.test.ts
+++ b/tests/event-seo-strategy.test.ts
@@ -16,6 +16,7 @@
 
 import {
   getEventSeoStrategy,
+  getDiscontinuedFormatReplacement,
   RECENT_EVENT_WINDOW_DAYS,
   CANCELLED_INDEX_DAYS,
 } from '@/lib/event-seo-strategy'
@@ -156,6 +157,20 @@ describe('getEventSeoStrategy', () => {
         slug: 'nikki-s-games-night-school-sports-day-special-2025-07-25',
       })
       expect(result.index).toBe(false)
+    })
+
+    it('points a games night at Music Bingo, not a generic listing', () => {
+      const replacement = getDiscontinuedFormatReplacement({
+        name: "Nikki's Games Night, Blankety Blank Special",
+      })
+      expect(replacement?.href).toBe('/music-bingo')
+      expect(replacement?.label).toBe('See Music Bingo dates')
+      // SSOT: "Nikki currently hosts Music Bingo only."
+      expect(replacement?.copy).toContain('Music Bingo')
+    })
+
+    it('returns no replacement for an event that still runs', () => {
+      expect(getDiscontinuedFormatReplacement({ name: 'Music Bingo' })).toBeNull()
     })
 
     it('keeps the page renderable, it is noindex not a redirect', () => {

--- a/tests/event-seo-strategy.test.ts
+++ b/tests/event-seo-strategy.test.ts
@@ -7,6 +7,9 @@
  * `CANCELLED_INDEX_DAYS`) and the redirect-vs-render-vs-noindex decisions can
  * silently drift, breaking GSC indexability for legitimate events or letting
  * stale events compete in search.
+ *
+ * Stale events redirect to their permanent category page, never to the next
+ * dated event. See the rationale on `getEventSeoStrategy`.
  */
 
 import {
@@ -34,15 +37,17 @@ function isoDaysFromNow(days: number): string {
   return new Date(FIXED_NOW + days * ONE_DAY_MS).toISOString()
 }
 
-const NEXT_EVENT = { id: 'next-event-id', slug: 'next-event-slug' }
+const MUSIC_BINGO = { id: 'cat-1', slug: 'music-bingo', name: 'Music Bingo', color: '#1a1a2e' }
+const UNMAPPED_CATEGORY = { id: 'cat-9', slug: 'something-unmapped', name: 'Other', color: '#1a1a2e' }
 
 describe('getEventSeoStrategy', () => {
   describe('active events (future, not cancelled)', () => {
     it('marks an upcoming scheduled event as indexable with no banner', () => {
-      const result = getEventSeoStrategy(
-        { startDate: isoDaysFromNow(3), event_status: 'scheduled', eventStatus: 'scheduled' },
-        null,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysFromNow(3),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+      })
       expect(result).toEqual({
         index: true,
         showEndedBanner: false,
@@ -52,10 +57,11 @@ describe('getEventSeoStrategy', () => {
     })
 
     it('marks an upcoming sold_out event as active and indexable', () => {
-      const result = getEventSeoStrategy(
-        { startDate: isoDaysFromNow(7), event_status: 'sold_out', eventStatus: 'sold_out' },
-        null,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysFromNow(7),
+        event_status: 'sold_out',
+        eventStatus: 'sold_out',
+      })
       expect(result.stage).toBe('active')
       expect(result.index).toBe(true)
       expect(result.redirect).toBeUndefined()
@@ -64,10 +70,11 @@ describe('getEventSeoStrategy', () => {
 
   describe('recent past events (≤ 30 days, not cancelled)', () => {
     it('keeps an event that ended yesterday indexable with the ended banner', () => {
-      const result = getEventSeoStrategy(
-        { startDate: isoDaysAgo(1), event_status: 'scheduled', eventStatus: 'scheduled' },
-        null,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(1),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+      })
       expect(result).toEqual({
         index: true,
         showEndedBanner: true,
@@ -77,14 +84,12 @@ describe('getEventSeoStrategy', () => {
     })
 
     it('keeps an event at exactly the 30-day boundary indexable (recent)', () => {
-      const result = getEventSeoStrategy(
-        {
-          startDate: isoDaysAgo(PAST_EVENT_REDIRECT_DAYS),
-          event_status: 'scheduled',
-          eventStatus: 'scheduled',
-        },
-        NEXT_EVENT,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(PAST_EVENT_REDIRECT_DAYS),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        category: MUSIC_BINGO,
+      })
       expect(result.stage).toBe('recent')
       expect(result.index).toBe(true)
       expect(result.redirect).toBeUndefined()
@@ -92,73 +97,90 @@ describe('getEventSeoStrategy', () => {
   })
 
   describe('stale past events (> 30 days)', () => {
-    it('redirects to the next event in category when one is supplied', () => {
-      const result = getEventSeoStrategy(
-        {
-          startDate: isoDaysAgo(PAST_EVENT_REDIRECT_DAYS + 1),
-          event_status: 'scheduled',
-          eventStatus: 'scheduled',
-        },
-        NEXT_EVENT,
-      )
+    it('redirects to the permanent category page, not to another dated event', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(PAST_EVENT_REDIRECT_DAYS + 1),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        category: MUSIC_BINGO,
+      })
       expect(result).toEqual({
         index: false,
-        redirect: `/events/${NEXT_EVENT.slug}`,
+        redirect: '/music-bingo',
         showEndedBanner: true,
         stage: 'stale',
       })
     })
 
-    it('falls back to event id when next event has no slug', () => {
-      const result = getEventSeoStrategy(
-        {
-          startDate: isoDaysAgo(45),
-          event_status: 'scheduled',
-          eventStatus: 'scheduled',
-        },
-        { id: 'fallback-id', slug: undefined as unknown as string },
-      )
-      expect(result.redirect).toBe('/events/fallback-id')
+    it('never redirects to another /events/ URL, whose own target would keep moving', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(90),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        category: MUSIC_BINGO,
+      })
+      expect(result.redirect).not.toMatch(/^\/events\//)
     })
 
-    it('renders with noindex when no next event exists', () => {
-      const result = getEventSeoStrategy(
-        {
-          startDate: isoDaysAgo(60),
-          event_status: 'scheduled',
-          eventStatus: 'scheduled',
-        },
-        null,
-      )
+    it('sends an uncategorised stale event to /whats-on', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(60),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+      })
       expect(result).toEqual({
         index: false,
+        redirect: '/whats-on',
         showEndedBanner: true,
         stage: 'stale',
       })
-      expect(result.redirect).toBeUndefined()
+    })
+
+    it('sends a category with no dedicated page to /whats-on', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(45),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        category: UNMAPPED_CATEGORY,
+      })
+      expect(result.redirect).toBe('/whats-on')
+    })
+
+    it('is deterministic: the same stale event always resolves to the same target', () => {
+      const event = {
+        startDate: isoDaysAgo(120),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        category: MUSIC_BINGO,
+      }
+      expect(getEventSeoStrategy(event).redirect).toBe(getEventSeoStrategy(event).redirect)
     })
   })
 
   describe('cancelled events', () => {
     it('keeps a recently cancelled event indexable for the 7-day window', () => {
-      const result = getEventSeoStrategy(
-        { startDate: isoDaysAgo(CANCELLED_INDEX_DAYS), event_status: 'cancelled', eventStatus: 'cancelled' },
-        NEXT_EVENT,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(CANCELLED_INDEX_DAYS),
+        event_status: 'cancelled',
+        eventStatus: 'cancelled',
+        category: MUSIC_BINGO,
+      })
       expect(result).toEqual({
         index: true,
         showEndedBanner: true,
         stage: 'stale',
       })
-      // Cancelled events never redirect — they render with the cancelled banner.
+      // Cancelled events never redirect, they render with the cancelled banner.
       expect(result.redirect).toBeUndefined()
     })
 
     it('marks an old cancelled event as noindex but does not redirect', () => {
-      const result = getEventSeoStrategy(
-        { startDate: isoDaysAgo(CANCELLED_INDEX_DAYS + 1), event_status: 'cancelled', eventStatus: 'cancelled' },
-        NEXT_EVENT,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(CANCELLED_INDEX_DAYS + 1),
+        event_status: 'cancelled',
+        eventStatus: 'cancelled',
+        category: MUSIC_BINGO,
+      })
       expect(result.index).toBe(false)
       expect(result.showEndedBanner).toBe(true)
       expect(result.stage).toBe('stale')
@@ -169,10 +191,12 @@ describe('getEventSeoStrategy', () => {
       // A cancelled event with a future date (cancelled in advance) should
       // still be indexable for the 7-day window from event date, never
       // redirected.
-      const result = getEventSeoStrategy(
-        { startDate: isoDaysFromNow(2), event_status: 'cancelled', eventStatus: 'cancelled' },
-        NEXT_EVENT,
-      )
+      const result = getEventSeoStrategy({
+        startDate: isoDaysFromNow(2),
+        event_status: 'cancelled',
+        eventStatus: 'cancelled',
+        category: MUSIC_BINGO,
+      })
       expect(result.index).toBe(true)
       expect(result.redirect).toBeUndefined()
     })

--- a/tests/event-seo-strategy.test.ts
+++ b/tests/event-seo-strategy.test.ts
@@ -2,19 +2,21 @@
  * Event lifecycle SEO strategy tests.
  *
  * Locks in the behaviour documented in
- * tasks/gsc-indexing-fix/url-lifecycle-policy.md §1 (events). Without these
- * tests, the lifecycle thresholds (`PAST_EVENT_REDIRECT_DAYS`,
- * `CANCELLED_INDEX_DAYS`) and the redirect-vs-render-vs-noindex decisions can
- * silently drift, breaking GSC indexability for legitimate events or letting
- * stale events compete in search.
+ * tasks/gsc-indexing-fix/url-lifecycle-policy.md §1 (events).
  *
- * Stale events redirect to their permanent category page, never to the next
- * dated event. See the rationale on `getEventSeoStrategy`.
+ * The headline rule: a past event is NEVER retired. It stays live and stays
+ * indexed so its content can accumulate ranking, because an event page is only
+ * live for a couple of months before the night itself and that is not long
+ * enough to earn anything. These tests exist to stop a future edit quietly
+ * reintroducing a redirect or a noindex on past events.
+ *
+ * Cancelled events are the single exception: nothing happened on the night, so
+ * there is no content worth ranking.
  */
 
 import {
   getEventSeoStrategy,
-  PAST_EVENT_REDIRECT_DAYS,
+  RECENT_EVENT_WINDOW_DAYS,
   CANCELLED_INDEX_DAYS,
 } from '@/lib/event-seo-strategy'
 
@@ -38,7 +40,6 @@ function isoDaysFromNow(days: number): string {
 }
 
 const MUSIC_BINGO = { id: 'cat-1', slug: 'music-bingo', name: 'Music Bingo', color: '#1a1a2e' }
-const UNMAPPED_CATEGORY = { id: 'cat-9', slug: 'something-unmapped', name: 'Other', color: '#1a1a2e' }
 
 describe('getEventSeoStrategy', () => {
   describe('active events (future, not cancelled)', () => {
@@ -53,7 +54,6 @@ describe('getEventSeoStrategy', () => {
         showEndedBanner: false,
         stage: 'active',
       })
-      expect(result.redirect).toBeUndefined()
     })
 
     it('marks an upcoming sold_out event as active and indexable', () => {
@@ -64,12 +64,11 @@ describe('getEventSeoStrategy', () => {
       })
       expect(result.stage).toBe('active')
       expect(result.index).toBe(true)
-      expect(result.redirect).toBeUndefined()
     })
   })
 
-  describe('recent past events (≤ 30 days, not cancelled)', () => {
-    it('keeps an event that ended yesterday indexable with the ended banner', () => {
+  describe('past events are kept and stay indexed', () => {
+    it('keeps an event that ended yesterday indexed, with the ended banner', () => {
       const result = getEventSeoStrategy({
         startDate: isoDaysAgo(1),
         event_status: 'scheduled',
@@ -80,84 +79,98 @@ describe('getEventSeoStrategy', () => {
         showEndedBanner: true,
         stage: 'recent',
       })
-      expect(result.redirect).toBeUndefined()
     })
 
-    it('keeps an event at exactly the 30-day boundary indexable (recent)', () => {
-      const result = getEventSeoStrategy({
-        startDate: isoDaysAgo(PAST_EVENT_REDIRECT_DAYS),
-        event_status: 'scheduled',
-        eventStatus: 'scheduled',
-        category: MUSIC_BINGO,
-      })
-      expect(result.stage).toBe('recent')
-      expect(result.index).toBe(true)
-      expect(result.redirect).toBeUndefined()
-    })
-  })
+    it.each([31, 60, 180, 365, 900])(
+      'still indexes an event %i days after it happened',
+      (days) => {
+        const result = getEventSeoStrategy({
+          startDate: isoDaysAgo(days),
+          event_status: 'scheduled',
+          eventStatus: 'scheduled',
+          category: MUSIC_BINGO,
+        })
+        expect(result.index).toBe(true)
+        expect(result.showEndedBanner).toBe(true)
+      },
+    )
 
-  describe('stale past events (> 30 days)', () => {
-    it('redirects to the permanent category page, not to another dated event', () => {
-      const result = getEventSeoStrategy({
-        startDate: isoDaysAgo(PAST_EVENT_REDIRECT_DAYS + 1),
-        event_status: 'scheduled',
-        eventStatus: 'scheduled',
-        category: MUSIC_BINGO,
-      })
-      expect(result).toEqual({
-        index: false,
-        redirect: '/music-bingo',
-        showEndedBanner: true,
-        stage: 'stale',
-      })
-    })
-
-    it('never redirects to another /events/ URL, whose own target would keep moving', () => {
-      const result = getEventSeoStrategy({
-        startDate: isoDaysAgo(90),
-        event_status: 'scheduled',
-        eventStatus: 'scheduled',
-        category: MUSIC_BINGO,
-      })
-      expect(result.redirect).not.toMatch(/^\/events\//)
-    })
-
-    it('sends an uncategorised stale event to /whats-on', () => {
-      const result = getEventSeoStrategy({
-        startDate: isoDaysAgo(60),
-        event_status: 'scheduled',
-        eventStatus: 'scheduled',
-      })
-      expect(result).toEqual({
-        index: false,
-        redirect: '/whats-on',
-        showEndedBanner: true,
-        stage: 'stale',
-      })
-    })
-
-    it('sends a category with no dedicated page to /whats-on', () => {
-      const result = getEventSeoStrategy({
-        startDate: isoDaysAgo(45),
-        event_status: 'scheduled',
-        eventStatus: 'scheduled',
-        category: UNMAPPED_CATEGORY,
-      })
-      expect(result.redirect).toBe('/whats-on')
-    })
-
-    it('is deterministic: the same stale event always resolves to the same target', () => {
-      const event = {
-        startDate: isoDaysAgo(120),
-        event_status: 'scheduled',
-        eventStatus: 'scheduled',
-        category: MUSIC_BINGO,
+    it('never returns a redirect for a past event, at any age', () => {
+      for (const days of [1, 30, 31, 400]) {
+        const result = getEventSeoStrategy({
+          startDate: isoDaysAgo(days),
+          event_status: 'scheduled',
+          eventStatus: 'scheduled',
+          category: MUSIC_BINGO,
+        }) as unknown as Record<string, unknown>
+        // A redirect would delete the content this policy exists to keep.
+        expect(result.redirect).toBeUndefined()
       }
-      expect(getEventSeoStrategy(event).redirect).toBe(getEventSeoStrategy(event).redirect)
+    })
+
+    it('switches stage from recent to archived at the window boundary, without changing indexability', () => {
+      const recent = getEventSeoStrategy({
+        startDate: isoDaysAgo(RECENT_EVENT_WINDOW_DAYS),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+      })
+      const archived = getEventSeoStrategy({
+        startDate: isoDaysAgo(RECENT_EVENT_WINDOW_DAYS + 1),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+      })
+      expect(recent.stage).toBe('recent')
+      expect(archived.stage).toBe('archived')
+      expect(recent.index).toBe(true)
+      expect(archived.index).toBe(true)
     })
   })
 
-  describe('cancelled events', () => {
+  describe('discontinued formats (SSOT)', () => {
+    // docs/SSOT.md: "Do not promote Nikki hosted/games nights as a recurring
+    // format. Nikki currently hosts Music Bingo only."
+    it('noindexes a past games night even though other past events are kept', () => {
+      const gamesNight = getEventSeoStrategy({
+        startDate: isoDaysAgo(200),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: "Nikki's Games Night, Blankety Blank Special",
+        slug: 'nikki-s-games-night-blankety-blank-special-2025-09-24',
+      })
+      const musicBingo = getEventSeoStrategy({
+        startDate: isoDaysAgo(200),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Music Bingo',
+        slug: 'music-bingo-2025-09-24',
+      })
+      expect(gamesNight.index).toBe(false)
+      expect(musicBingo.index).toBe(true)
+    })
+
+    it('matches on the slug as well as the name', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(10),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        slug: 'nikki-s-games-night-school-sports-day-special-2025-07-25',
+      })
+      expect(result.index).toBe(false)
+    })
+
+    it('keeps the page renderable, it is noindex not a redirect', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(200),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: "Nikki's Games Night",
+      }) as unknown as Record<string, unknown>
+      expect(result.redirect).toBeUndefined()
+      expect(result.showEndedBanner).toBe(true)
+    })
+  })
+
+  describe('cancelled events, the one exception', () => {
     it('keeps a recently cancelled event indexable for the 7-day window', () => {
       const result = getEventSeoStrategy({
         startDate: isoDaysAgo(CANCELLED_INDEX_DAYS),
@@ -168,13 +181,11 @@ describe('getEventSeoStrategy', () => {
       expect(result).toEqual({
         index: true,
         showEndedBanner: true,
-        stage: 'stale',
+        stage: 'archived',
       })
-      // Cancelled events never redirect, they render with the cancelled banner.
-      expect(result.redirect).toBeUndefined()
     })
 
-    it('marks an old cancelled event as noindex but does not redirect', () => {
+    it('noindexes an old cancelled event, because nothing happened to rank', () => {
       const result = getEventSeoStrategy({
         startDate: isoDaysAgo(CANCELLED_INDEX_DAYS + 1),
         event_status: 'cancelled',
@@ -183,14 +194,9 @@ describe('getEventSeoStrategy', () => {
       })
       expect(result.index).toBe(false)
       expect(result.showEndedBanner).toBe(true)
-      expect(result.stage).toBe('stale')
-      expect(result.redirect).toBeUndefined()
     })
 
-    it('treats a future cancelled event as still cancelled (no redirect)', () => {
-      // A cancelled event with a future date (cancelled in advance) should
-      // still be indexable for the 7-day window from event date, never
-      // redirected.
+    it('treats a future cancelled event as still cancelled', () => {
       const result = getEventSeoStrategy({
         startDate: isoDaysFromNow(2),
         event_status: 'cancelled',
@@ -198,7 +204,6 @@ describe('getEventSeoStrategy', () => {
         category: MUSIC_BINGO,
       })
       expect(result.index).toBe(true)
-      expect(result.redirect).toBeUndefined()
     })
   })
 })

--- a/tests/unit/event-schema.test.ts
+++ b/tests/unit/event-schema.test.ts
@@ -1,11 +1,19 @@
 import { buildEventSchema } from '@/lib/structured-data/event-schema'
 import { CATEGORY_ROUTES } from '@/lib/event-seo-strategy'
 
+// These tests cover offer and action sanitisation, which only applies to an
+// event that is still bookable. The date must therefore stay in the future.
+// It was previously hardcoded to 2026-06-01, which silently became a past date
+// and made every assertion here depend on when the suite was run.
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+const futureStart = new Date(Date.now() + 30 * ONE_DAY_MS)
+const futureEnd = new Date(futureStart.getTime() + 3 * 60 * 60 * 1000)
+
 const minimalEvent = {
   id: 'test-1',
   name: 'Test Event',
-  startDate: '2026-06-01T19:00:00Z',
-  endDate: '2026-06-01T22:00:00Z',
+  startDate: futureStart.toISOString(),
+  endDate: futureEnd.toISOString(),
   offers: { price: '5', priceCurrency: 'GBP' }
 } as any
 

--- a/tests/unit/event-url.test.ts
+++ b/tests/unit/event-url.test.ts
@@ -34,43 +34,45 @@ describe('getEventWebsitePath', () => {
     expect(result).toBe('/events/quiz-night-april-2026')
   })
 
-  // event.url fallback — non-event paths rejected
+  // event.url fallback, non-event paths rejected.
+  // The fallback is /whats-on, not /events: there is no /events index route, so
+  // the old fallback pointed every unusable event at a 404.
   it('rejects event.url pointing to a category page', () => {
     const result = getEventWebsitePath(makeSource({
       url: 'https://www.the-anchor.pub/quiz-night'
     }))
-    expect(result).toBe('/events')
+    expect(result).toBe('/whats-on')
   })
 
   it('rejects event.url pointing to /whats-on', () => {
     const result = getEventWebsitePath(makeSource({
       url: 'https://www.the-anchor.pub/whats-on'
     }))
-    expect(result).toBe('/events')
+    expect(result).toBe('/whats-on')
   })
 
   it('rejects event.url from an external origin', () => {
     const result = getEventWebsitePath(makeSource({
       url: 'https://tickets.example.com/event/123'
     }))
-    expect(result).toBe('/events')
+    expect(result).toBe('/whats-on')
   })
 
   it('rejects bare string event.url resolved to root-level path', () => {
     const result = getEventWebsitePath(makeSource({ url: 'summer-quiz' }))
-    expect(result).toBe('/events')
+    expect(result).toBe('/whats-on')
   })
 
   it('rejects category page URL with trailing slash', () => {
     const result = getEventWebsitePath(makeSource({
       url: 'https://www.the-anchor.pub/quiz-night/'
     }))
-    expect(result).toBe('/events')
+    expect(result).toBe('/whats-on')
   })
 
-  it('falls through to /events when slug, id, and url are all empty', () => {
+  it('falls through to /whats-on when slug, id, and url are all empty', () => {
     const result = getEventWebsitePath(makeSource())
-    expect(result).toBe('/events')
+    expect(result).toBe('/whats-on')
   })
 
   it('treats whitespace-only slug and id as empty', () => {


### PR DESCRIPTION
## What changed

Two things, and the second reverses earlier behaviour.

**1. Past event pages now stay live and indexed, at any age.** They used to go `noindex` and 301 away at 30 days. An event page went up a few weeks before the night and vanished 30 days after it, so it was live for roughly two months, which is not long enough to earn rankings. Every month the site threw away the page it had just built. The route into the next date is now an on-page link, never a redirect, because a redirect deletes the content this policy exists to keep. Sitemap event count goes from 5 to 57.

**2. The expired-page state is fixed,** which is what makes point 1 safe.

## Why

`/events/music-bingo-2026-07-17` displayed "This event has ended" while its structured data emitted `offers.availability: InStock`, a `ReserveAction`, remaining capacity, and a `validFrom` regenerated on every crawl.

The page derived `bookingFormSuppressed` locally and gated only three of nine booking surfaces with it, so an ended event still rendered a booking policy card, booking FAQs, a "Ready to book" CTA, a share button and a "Status: Scheduled" row. All of that now resolves from one module, `lib/event-presentation.ts`, which the JSON-LD reads from too, so the page and its markup cannot disagree.

Those two fixes are load-bearing for the indexing change: a page that is indexed forever and still says "Book now" for a night in 2026 would be worse than no page at all.

## Testing done

- [x] Manual testing against the live management API. A 55-day-old event (`music-bingo-2026-06-12`) returns 200 and `index, follow` where it previously 308'd away; it shows the ended banner, names the date, links "Next Music Bingo: Friday, 14 August 2026", leads its CTA with "Book the next one", and its JSON-LD carries no `offers` or `potentialAction`. Upcoming events are unchanged. Sitemap verified at 57 event URLs.
- [x] Automated tests: 1309 passing. New `tests/event-presentation.test.ts` and `tests/event-schema-lifecycle.test.ts`; `tests/event-seo-strategy.test.ts` rewritten to lock in "past events are never retired" at 31, 60, 180, 365 and 900 days.

## Assumptions and notes

- **Duplicate content was checked, not assumed.** The six past Music Bingo nights carry six distinct names, themes and highlight sets. They are genuinely different pages, not one template repeated.
- **SSOT conflict found and handled.** Publishing 43 previously hidden pages surfaced two "Nikki's Games Night" events, which `docs/SSOT.md` says must not be promoted as a recurring format. `isDiscontinuedFormatEvent()` keeps them live but `noindex` and out of the sitemap. Open mic was already handled separately because it has a real replacement page to 301 to.
- `eventStatus` deliberately stays `EventScheduled` on a past event. schema.org has no completed status, so the past `startDate` is what signals the event is over. Pairing that date with a live offer was the defect.
- The upstream `validFrom` timestamp still arrives from the management API stamped at request time. Dropping offers on past events removes the visible symptom; the API side is tracked separately.
- `PAST_EVENT_REDIRECT_DAYS` renamed to `RECENT_EVENT_WINDOW_DAYS`, since it no longer governs a redirect. `lib/api/events.ts` imports it rather than declaring its own 30, so the listing window and the page wording cannot drift.
- `tests/unit/event-schema.test.ts` hardcoded `startDate: 2026-06-01`, future when written and past since June, so its offer assertions had quietly started testing an ended event. Now relative to `now`.

## Complexity score

M

## Breaking changes

`getEventSeoStrategy` no longer returns `redirect` and no longer takes a second argument. Internal, single caller. `isFallbackEvent` removed with the lookup it served.

## Migration risk

Medium. This republishes 41 event URLs that were previously noindex. That is the intent, but it is a visible change in indexed surface area and worth watching in GSC over the following weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)