### PR TITLE
fix(schema): stop the event series expiring, and restore the missing prices

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -185,15 +185,32 @@ export const webSiteSchema = {
 
 export const restaurantSchema = localBusinessSchema
 
+/**
+ * Horizon for our open-ended recurring event series.
+ *
+ * These series have no planned end, but schema.org consumers expect a concrete
+ * endDate, and a hardcoded one silently rots: the previous "2026-12-31" would
+ * have told Google the quiz and bingo series had finished from 1 January 2027,
+ * with nothing in the deploy pipeline to catch it. Rolling to 31 December of
+ * next year keeps the horizon between 12 and 24 months out at all times and
+ * removes the annual manual bump.
+ *
+ * The value changes once a year, on 1 January, so it is stable for crawlers.
+ * `tests/unit/schema.test.ts` asserts it stays at least 90 days out.
+ */
+function rollingSeriesEndDate(now: Date = new Date()): string {
+  return `${now.getUTCFullYear() + 1}-12-31`
+}
+
 // Event Series Schemas for Regular Events
 export const quizNightEventSeries = {
   "@context": "https://schema.org",
   "@type": "EventSeries",
   "@id": "https://www.the-anchor.pub/#quiz-night-series",
   "name": "Monthly Quiz Night at The Anchor",
-  "description": "Test your knowledge at our popular monthly quiz night. 3 entry, teams up to 6, great prizes including a 25 bar voucher for winners.",
+  "description": "Test your knowledge at our popular monthly quiz night. £3 per person, teams up to 6, with a £25 bar tab for the winners.",
   "startDate": "2024-01-01",
-  "endDate": "2026-12-31",
+  "endDate": rollingSeriesEndDate(),
   "eventSchedule": {
     "@type": "Schedule",
     "repeatFrequency": "P1M",
@@ -244,9 +261,9 @@ export const bingoEventSeries = {
   "@type": "EventSeries",
   "@id": "https://www.the-anchor.pub/#bingo-series",
   "name": "Monthly Cash Bingo Night",
-  "description": "Monthly bingo night with 10 per book entry. 10 games with various prizes including drinks, chocolate, vouchers, and cash jackpot on the last game.",
+  "description": "Monthly bingo night, £10 per book, cash only. 10 games with various prizes including drinks, chocolate, vouchers, and a cash jackpot on the last game.",
   "startDate": "2024-01-01",
-  "endDate": "2026-12-31",
+  "endDate": rollingSeriesEndDate(),
   "eventSchedule": {
     "@type": "Schedule",
     "repeatFrequency": "P1M",
@@ -296,7 +313,7 @@ export const liveMusicEventSeries = {
   "name": "Live at The Anchor, Live Music Nights",
   "description": "Regular live music nights at The Anchor, Stanwell Moor, bands, acoustic sessions and tribute acts. Free entry, free parking, 7 mins from Heathrow T5.",
   "startDate": "2024-01-01",
-  "endDate": "2026-12-31",
+  "endDate": rollingSeriesEndDate(),
   "eventSchedule": {
     "@type": "Schedule",
     "repeatFrequency": "P1M",

--- a/tests/unit/ManagementEventBookingForm.test.tsx
+++ b/tests/unit/ManagementEventBookingForm.test.tsx
@@ -12,6 +12,18 @@ jest.mock('@/lib/gtm-events', () => ({
   trackEventBookingFunnelStep: jest.fn()
 }))
 
+/**
+ * Attribution capture time, held five days back from whenever the suite runs.
+ *
+ * This was previously the literal '2026-05-08T18:30:00.000Z'. Attribution has a
+ * 90 day TTL (ATTRIBUTION_TTL_DAYS in lib/booking-attribution.ts), so on
+ * 2026-08-06 that fixture aged out and the test started failing: the UTM fields
+ * were dropped on read and utm_source came back undefined. Keeping the fixture
+ * relative to now means the test exercises live attribution forever, instead of
+ * silently becoming an expiry test and then a failure.
+ */
+const CAPTURED_AT = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+
 describe('ManagementEventBookingForm', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -223,7 +235,7 @@ describe('ManagementEventBookingForm', () => {
       '',
       '/events/music-bingo?utm_source=facebook&utm_medium=paid_social&utm_campaign=music-bingo&gclid=g-123&short_code=ma-bingo&email=jane@example.com',
     )
-    captureBookingAttributionFromLocation(new Date('2026-05-08T18:30:00.000Z'))
+    captureBookingAttributionFromLocation(CAPTURED_AT)
     window.history.pushState({}, '', '/events/music-bingo')
 
     render(
@@ -278,7 +290,7 @@ describe('ManagementEventBookingForm', () => {
     expect(payload.utm_campaign).toBe('music-bingo')
     expect(payload.gclid).toBe('g-123')
     expect(payload.short_code).toBe('ma-bingo')
-    expect(payload.attribution_captured_at).toBe('2026-05-08T18:30:00.000Z')
+    expect(payload.attribution_captured_at).toBe(CAPTURED_AT.toISOString())
     expect(payload.email).toBeUndefined()
     expect(JSON.stringify(payload)).not.toContain('jane@example.com')
     expect(payload.communication_consent).toEqual(

--- a/tests/unit/ManagementTableBookingForm.test.tsx
+++ b/tests/unit/ManagementTableBookingForm.test.tsx
@@ -5,6 +5,14 @@ import {
   clearBookingAttributionForTest,
 } from '@/lib/booking-attribution'
 
+/**
+ * Held relative to whenever the suite runs. This was the literal
+ * '2026-07-10T11:30:00.000Z', which would have aged past the 90 day
+ * ATTRIBUTION_TTL_DAYS window in October 2026 and started dropping the UTM
+ * fields this test asserts on.
+ */
+const ATTRIBUTION_CAPTURED_AT = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+
 const trackTableBookingFunnel = jest.fn()
 const pushToDataLayer = jest.fn()
 const trackTableBookingClick = jest.fn()
@@ -763,7 +771,7 @@ describe('ManagementTableBookingForm', () => {
       '',
       '/book-table?utm_source=facebook&utm_medium=paid_social&utm_campaign=deposit-table&fbclid=fb-123&gclid=g-123&short_code=ma-table&email=jane@example.com',
     )
-    captureBookingAttributionFromLocation(new Date('2026-07-10T11:30:00.000Z'))
+    captureBookingAttributionFromLocation(ATTRIBUTION_CAPTURED_AT)
     window.history.pushState({}, '', '/book-table')
 
     render(<ManagementTableBookingForm />)
@@ -816,7 +824,7 @@ describe('ManagementTableBookingForm', () => {
     expect(payload.fbclid).toBe('fb-123')
     expect(payload.gclid).toBe('g-123')
     expect(payload.short_code).toBe('ma-table')
-    expect(payload.attribution_captured_at).toBe('2026-07-10T11:30:00.000Z')
+    expect(payload.attribution_captured_at).toBe(ATTRIBUTION_CAPTURED_AT.toISOString())
     expect(payload.email).toBeUndefined()
     expect(JSON.stringify(payload)).not.toContain('jane@example.com')
     expect(payload.communication_consent).toEqual(

--- a/tests/unit/booking-attribution.test.ts
+++ b/tests/unit/booking-attribution.test.ts
@@ -6,6 +6,23 @@ import {
 } from '@/lib/booking-attribution'
 import { setConsentStatus } from '@/lib/cookies'
 
+/**
+ * Capture times held relative to whenever the suite runs.
+ *
+ * These were the literals '2026-05-10T10:00:00.000Z' and
+ * '2026-05-11T11:00:00.000Z'. Attribution has a 90 day TTL
+ * (ATTRIBUTION_TTL_DAYS in lib/booking-attribution.ts), so those fixtures were
+ * two days from ageing out, at which point getBookingAttributionPayload would
+ * start returning nothing and these tests would fail for a reason that has
+ * nothing to do with the behaviour under test.
+ *
+ * FIRST_SEEN stays older than LATER_SEEN so the "keeps first landing context
+ * while updating latest campaign params" case still exercises real ordering.
+ */
+const DAY_MS = 24 * 60 * 60 * 1000
+const FIRST_SEEN = new Date(Date.now() - 5 * DAY_MS)
+const LATER_SEEN = new Date(Date.now() - 4 * DAY_MS)
+
 describe('booking attribution persistence', () => {
   beforeEach(() => {
     clearBookingAttributionForTest()
@@ -30,7 +47,7 @@ describe('booking attribution persistence', () => {
       '/events/music-bingo?utm_source=facebook&utm_medium=paid_social&utm_campaign=music-bingo&utm_content=ad-1&fbclid=fb-123&gclid=g-123&short_code=ma83ed9d&email=jane@example.com&phone=07700900000',
     )
 
-    const payload = captureBookingAttributionFromLocation(new Date('2026-05-10T10:00:00.000Z'))
+    const payload = captureBookingAttributionFromLocation(FIRST_SEEN)
 
     expect(payload).toMatchObject({
       source_url: 'http://localhost/events/music-bingo?utm_source=facebook&utm_medium=paid_social&utm_campaign=music-bingo&utm_content=ad-1&fbclid=fb-123&gclid=g-123&short_code=ma83ed9d',
@@ -42,8 +59,8 @@ describe('booking attribution persistence', () => {
       fbclid: 'fb-123',
       gclid: 'g-123',
       short_code: 'ma83ed9d',
-      attribution_captured_at: '2026-05-10T10:00:00.000Z',
-      attribution_updated_at: '2026-05-10T10:00:00.000Z',
+      attribution_captured_at: FIRST_SEEN.toISOString(),
+      attribution_updated_at: FIRST_SEEN.toISOString(),
     })
     expect(JSON.stringify(payload)).not.toMatch(/jane@example\.com|07700900000|email|phone/)
     expect(window.localStorage.getItem('anchor-booking-attribution')).toContain('music-bingo')
@@ -51,24 +68,24 @@ describe('booking attribution persistence', () => {
 
   it('keeps first landing context while updating latest campaign params', () => {
     window.history.pushState({}, '', '/events/quiz-night?utm_campaign=quiz-night&fbclid=fb-first')
-    captureBookingAttributionFromLocation(new Date('2026-05-10T10:00:00.000Z'))
+    captureBookingAttributionFromLocation(FIRST_SEEN)
 
     window.history.pushState({}, '', '/book-table?utm_campaign=sunday-lunch&gclid=g-latest')
-    const latestPayload = captureBookingAttributionFromLocation(new Date('2026-05-11T11:00:00.000Z'))
+    const latestPayload = captureBookingAttributionFromLocation(LATER_SEEN)
 
     expect(latestPayload).toMatchObject({
       source_url: 'http://localhost/events/quiz-night?utm_campaign=quiz-night&fbclid=fb-first',
       landing_path: '/events/quiz-night',
       utm_campaign: 'sunday-lunch',
       gclid: 'g-latest',
-      attribution_captured_at: '2026-05-10T10:00:00.000Z',
-      attribution_updated_at: '2026-05-11T11:00:00.000Z',
+      attribution_captured_at: FIRST_SEEN.toISOString(),
+      attribution_updated_at: LATER_SEEN.toISOString(),
     })
   })
 
   it('returns stored attribution after visitors navigate away from campaign URLs', () => {
     window.history.pushState({}, '', '/events/quiz-night?utm_campaign=quiz-night&short_code=ma-quiz')
-    captureBookingAttributionFromLocation(new Date('2026-05-10T10:00:00.000Z'))
+    captureBookingAttributionFromLocation(FIRST_SEEN)
 
     window.history.pushState({}, '', '/book-table')
 


### PR DESCRIPTION
## What changed

Three fixes found while auditing after the past-event indexing change.

**1. The recurring event series were set to expire.** `quizNightEventSeries`, `bingoEventSeries` and `liveMusicEventSeries` in `lib/schema.ts` each carried a hardcoded `"endDate": "2026-12-31"`. From 1 January 2027 the live JSON-LD would have told Google those series had finished. `endDate` now rolls to 31 December of next year, so the horizon stays 12 to 24 months out and nobody has to remember an annual bump.

**2. The pound signs were missing from those descriptions.** The live markup read "3 entry", "a 25 bar voucher for winners" and "10 per book entry". Restored from `docs/SSOT.md`: £3 per person, a £25 bar tab (the SSOT says tab, not voucher) and £10 per book, cash only.

**3. Three time-bomb tests.** Attribution has a 90 day TTL, and each of these pinned its capture time to a date literal:

| Test | Fixture | Status |
|---|---|---|
| `ManagementEventBookingForm.test.tsx` | 2026-05-08 | already failing on main today |
| `booking-attribution.test.ts` | 2026-05-10 | would have failed 2026-08-08 |
| `ManagementTableBookingForm.test.tsx` | 2026-07-10 | would have failed 2026-10-08 |

All three now hold their capture time relative to the run.

## Why

The first two are live defects that no test would have caught, because nothing asserts on that copy and the expiry was still months away. The `schema.test.ts` assertion that `endDate` stays more than 90 days out is a good alarm; it just fires 90 days before the damage, and it had not fired yet.

The test fixtures matter because a time bomb does not announce itself as a time bomb. `ManagementEventBookingForm` was failing on main with `utm_source` undefined, which reads like an attribution regression rather than an expired fixture.

## Testing done

- [x] Automated tests: 1311 passing, 123 suites, including the 34-case SSOT drift guard.
- [x] Verified the rendered schema: all three series now emit `endDate=2027-12-31` (511 days out) and the descriptions carry their pound signs.
- [x] `npx tsc --noEmit` clean, lint clean.

## Assumptions

- A rolling `endDate` is preferable to omitting it. These series are genuinely open-ended, and schema.org would allow no `endDate`, but keeping a concrete horizon preserves the existing `schema.test.ts` alarm. It changes once a year, on 1 January, so it is stable for crawlers.
- Restoring pound signs here does not conflict with the bare-menu-price convention. That applies to per-item menu prices; this is prose in a description.

## Complexity score

S

## Breaking changes

None.

## Migration risk

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)