### PR TITLE
fix(events): make past event pages read as history, not as live adverts

### DIFF
--- a/app/events/[id]/opengraph-image.tsx
+++ b/app/events/[id]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from 'next/og'
 import { anchorAPI, formatEventTime } from '@/lib/api'
 import { getEventDateRangeUtc } from '@/lib/event-calendar'
 import { getEventPriceLabel } from '@/lib/event-pricing'
+import { getEventPresentation } from '@/lib/event-presentation'
 
 export const runtime = 'nodejs'
 
@@ -20,12 +21,18 @@ export default async function OpenGraphImage({ params }: { params: { id: string 
   let timeLabel = ''
   let categoryLabel = 'Live event'
   let priceLabel = ''
+  let hasEnded = false
 
   try {
     const event = await anchorAPI.getEvent(params.id)
     title = event.name || title
     categoryLabel = event.category?.name || categoryLabel
-    priceLabel = getEventPriceLabel(event) || ''
+    // Same resolver as the page and the JSON-LD. A shared link to a night that
+    // has already happened must not look like an advert for one that has not:
+    // the price and start time are booking facts, not historical ones.
+    hasEnded = getEventPresentation(event).hasEnded
+
+    priceLabel = hasEnded ? '' : getEventPriceLabel(event) || ''
 
     const start = getEventDateRangeUtc(event).start
     if (!Number.isNaN(start.getTime())) {
@@ -33,15 +40,18 @@ export default async function OpenGraphImage({ params }: { params: { id: string 
         weekday: 'short',
         day: 'numeric',
         month: 'short',
+        ...(hasEnded ? { year: 'numeric' as const } : {}),
         timeZone: LONDON_TIME_ZONE
       })
     }
-    timeLabel = formatEventTime(event.startDate)
+    timeLabel = hasEnded ? '' : formatEventTime(event.startDate)
   } catch {
     // fall back to defaults
   }
 
-  const metaLine = [dateLabel, timeLabel].filter(Boolean).join(' • ')
+  const metaLine = [hasEnded ? 'Event ended' : null, dateLabel, timeLabel]
+    .filter(Boolean)
+    .join(' • ')
 
   return new ImageResponse(
     (

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -35,8 +35,9 @@ import {
 import { getEventPriceLabel } from '@/lib/event-pricing'
 import { getEventBookingCopy } from '@/lib/event-booking-copy'
 import { getEventBookingHeroStatement } from '@/lib/event-booking-experience'
-import { getEventSeoStrategy, getCategoryPageUrl, isDiscontinuedFormatEvent, getDiscontinuedFormatReplacement, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
+import { getEventSeoStrategy, getCategoryPageUrl, isDiscontinuedFormatEvent, getDiscontinuedFormatReplacement, getSafeAccessibilityNotes, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
 import { getEventPresentation } from '@/lib/event-presentation'
+import { getEventMetaDescription, getDisplayableFaqs } from '@/lib/event-copy'
 import { getUpcomingEventsByCategory, isRetiredEvent } from '@/lib/api/events'
 import type { Event } from '@/lib/api'
 import RelatedEvents from '@/components/events/RelatedEvents'
@@ -71,6 +72,20 @@ function getStatusNotice(
     }
   }
 
+  // Asked before rescheduled and sold_out: a night that sold out and has since
+  // happened is over, and "call us to check cancellations" would be nonsense.
+  // Cancelled and postponed stay above this, because those nights never took
+  // place, so "It took place on <date>" would be false for them.
+  if (pastEvent) {
+    return {
+      variant: 'info',
+      title: 'This event has ended',
+      message: eventDate
+        ? `It took place on ${eventDate}. See below for the next dates.`
+        : 'See below for the next dates.'
+    }
+  }
+
   if (status === 'rescheduled') {
     return {
       variant: 'info',
@@ -84,16 +99,6 @@ function getStatusNotice(
       variant: 'info',
       title: 'This event is currently sold out',
       message: 'Call us to check cancellations or alternative options.'
-    }
-  }
-
-  if (pastEvent) {
-    return {
-      variant: 'info',
-      title: 'This event has ended',
-      message: eventDate
-        ? `It took place on ${eventDate}. See below for the next dates.`
-        : 'See below for the next dates.'
     }
   }
 
@@ -220,23 +225,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
     const canonical = `/events/${event.slug || params.id}`
     const ogImage = `${canonical}/opengraph-image`
-    const description =
-      event.metaDescription ||
-      event.shortDescription ||
-      event.description ||
-      `Join us for ${event.name} at The Anchor in Stanwell Moor. ${formatEventDate(event.startDate)} at ${formatEventTime(event.startDate)}.`
-    
-    // Past events stay indexed indefinitely so each night's content can
-    // accumulate. Only a long-cancelled event is noindexed: nothing happened,
-    // so there is nothing worth ranking.
-    const eventDate = Date.parse(event.startDate)
-    const daysSinceEvent = (Date.now() - eventDate) / (1000 * 60 * 60 * 24)
-    const eventStatus = normalizeEventStatus(event)
-    const shouldNoindex =
-      (eventStatus === 'cancelled' && daysSinceEvent > CANCELLED_INDEX_DAYS) ||
-      // SSOT: discontinued formats must not be promoted. Page stays live for
-      // anyone holding the link, but out of search.
-      isDiscontinuedFormatEvent(event)
+    // Past events never inherit their sales copy. That text was written to sell
+    // tickets and is future tense, so on a night that has passed it produces a
+    // search result inviting people to book a date months gone.
+    const description = getEventMetaDescription(
+      event,
+      `Join us for ${event.name} at The Anchor in Stanwell Moor. ${formatEventDate(event.startDate)} at ${formatEventTime(event.startDate)}.`,
+    )
+
+    // Indexability comes from getEventSeoStrategy, the same function the page
+    // body and app/sitemap.ts use. It previously lived here as its own copy of
+    // the rule, which is how the head and the sitemap were free to disagree.
+    const shouldNoindex = !getEventSeoStrategy(event).index
 
     // Merge keyword arrays
     const keywords = [
@@ -255,7 +255,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       },
       openGraph: {
         title: event.metaTitle || event.name,
-        description: event.shortDescription || event.description || `Event at The Anchor - ${formatEventDate(event.startDate)}`,
+        // Same resolver as the head description, so a shared link cannot
+        // advertise a night that has already happened.
+        description: getEventMetaDescription(
+          event,
+          `Event at The Anchor - ${formatEventDate(event.startDate)}`,
+        ),
         url: canonical,
         siteName: 'The Anchor',
         images: [
@@ -348,6 +353,11 @@ export default async function EventPage({ params }: Props) {
   const categoryPageUrl = discontinuedReplacement?.href ?? getCategoryPageUrl(event.category?.slug)
   const categoryPageLabel =
     discontinuedReplacement?.label ?? `All ${event.category?.name} dates`
+  const safeAccessibilityNotes = getSafeAccessibilityNotes(event)
+  const displayedFaqs = getDisplayableFaqs(
+    event.faq || event.faqPage?.mainEntity || [],
+    presentation.hasEnded,
+  )
   const nextEventHref = nextInCategory ? getEventWebsitePath(nextInCategory) : null
   const nextEventDate = nextInCategory ? formatEventDate(nextInCategory.startDate) : null
 
@@ -405,7 +415,10 @@ export default async function EventPage({ params }: Props) {
     { label: eventDate, variant: 'default' as const },
     { label: eventTime, variant: 'default' as const },
     ...(headerDoorTime ? [{ label: headerDoorTime, variant: 'default' as const }] : []),
-    ...(status !== 'scheduled'
+    // Gated on the same flag as the status row in the details list, so the hero
+    // cannot say "Status: Sold Out" on a night the rest of the page treats as
+    // finished.
+    ...(presentation.showStatusRow && status !== 'scheduled'
       ? [{ label: `Status: ${statusLabel}`, variant: 'warning' as const }]
       : [])
   ]
@@ -465,6 +478,7 @@ export default async function EventPage({ params }: Props) {
         eventDate={event.startDate}
         eventCategory={event.category?.name}
         eventPrice={event.offers?.price ? parseFloat(event.offers.price) : undefined}
+        hasEnded={presentation.hasEnded}
       />
 
       {statusNotice ? (
@@ -705,23 +719,24 @@ export default async function EventPage({ params }: Props) {
                 </CardBody>
               </Card>
 
-              {/* Accessibility */}
-              {event.accessibility_notes && (
+              {/* Accessibility. Withheld entirely when the stored notes carry a
+                  claim the SSOT verifies as false, because a wrong accessibility
+                  statement is worse than none: someone could plan a visit on it. */}
+              {safeAccessibilityNotes && (
                 <div className="p-3 rounded-md bg-surface-sunk border border-line">
                   <p className="text-xs font-medium text-accent-text mb-1">Accessibility</p>
-                  <p className="text-sm text-ink-muted">{event.accessibility_notes}</p>
+                  <p className="text-sm text-ink-muted">{safeAccessibilityNotes}</p>
                 </div>
               )}
 
-              {/* FAQs. Overwhelmingly booking questions, so they are hidden once
-                  the event is over rather than telling visitors how to book a
-                  night that has already happened. */}
-              {presentation.showBookingFaqs &&
-                ((event.faq && event.faq.length > 0) || (event.faqPage && event.faqPage.mainEntity.length > 0)) && (
+              {/* FAQs. On an ended event the booking questions go, but the rest
+                  stay: they are often the only unique prose on the page, and
+                  past pages are kept precisely so that content can accumulate. */}
+              {displayedFaqs.length > 0 && (
                 <div>
                   <h2 className="text-xl md:text-2xl text-accent-text mb-4 md:mb-6">Frequently Asked Questions</h2>
                   <div className="space-y-3 md:space-y-4">
-                    {(event.faq || event.faqPage?.mainEntity || []).map((faq, index) => (
+                    {displayedFaqs.map((faq, index) => (
                       <Card key={index} accent>
                         <CardBody className="p-4 md:p-6">
                           <h3 className="font-semibold text-base md:text-lg text-accent-text mb-2">{faq.name}</h3>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { getAllBlogPosts } from '@/lib/markdown'
 import { landmarks } from '@/lib/local-seo-data'
 import { anchorAPI, type Event } from '@/lib/api'
 import { getEventWebsitePath } from '@/lib/event-url'
-import { CANCELLED_INDEX_DAYS, isDiscontinuedFormatEvent } from '@/lib/event-seo-strategy'
+import { getEventSeoStrategy } from '@/lib/event-seo-strategy'
 import { isRetiredEvent } from '@/lib/api/events'
 
 export const revalidate = 60 * 60 // 1 hour
@@ -109,12 +109,9 @@ const DATES = {
   may2026: new Date('2026-05-12'),      // Recruitment pages
   may2026Late: new Date('2026-05-21'), // History page
   jul2026: new Date('2026-07-10'),      // Christmas page and booking journey refresh
+  jul2026Early: new Date('2026-07-07'), // Anniversary parties content remediation
+  jul2026Late: new Date('2026-07-19'),  // Dining and roast cluster consolidation
 } as const
-
-// Pages we want Google to recrawl promptly report a rolling lastModified
-// anchored to the most recent sitemap regeneration (revalidated hourly). Using
-// a frozen constant told crawlers nothing had changed and slowed re-indexing.
-const RECENTLY_UPDATED = new Date()
 
 type StaticRoute = { path: string; lastModified: Date }
 
@@ -140,13 +137,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: '/mothers-day', lastModified: DATES.seoOverhaul },
     { path: '/valentines-day', lastModified: DATES.seoOverhaul },
     { path: '/new-years-eve', lastModified: DATES.seoOverhaul },
-    { path: '/easter-sunday', lastModified: RECENTLY_UPDATED },
+    { path: '/easter-sunday', lastModified: DATES.jul2026Late },
     { path: '/fathers-day', lastModified: DATES.seoOverhaul },
     { path: '/halloween', lastModified: DATES.seoOverhaul },
     // /st-patricks-day, /boxing-day, /bonfire-night and /bank-holiday-weekends
     // are now 301-redirected (see config/redirects/additional-redirects.json)
     // and their route dirs deleted, so they are intentionally omitted here.
-    { path: '/sunday-roast', lastModified: RECENTLY_UPDATED },
+    { path: '/sunday-roast', lastModified: DATES.jul2026Late },
     { path: '/pizza-menu', lastModified: DATES.seoOverhaul },
     { path: '/fish-and-chips-heathrow', lastModified: DATES.seoOverhaul },
     { path: '/drinks', lastModified: DATES.apr2026 },
@@ -176,7 +173,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: '/private-hire/wakes', lastModified: DATES.seoOverhaul },
     { path: '/private-hire/christenings', lastModified: DATES.seoOverhaul },
     { path: '/private-hire/baby-showers', lastModified: DATES.seoOverhaul },
-    { path: '/private-hire/anniversary-parties', lastModified: RECENTLY_UPDATED },
+    { path: '/private-hire/anniversary-parties', lastModified: DATES.jul2026Early },
     { path: '/private-hire/engagement-parties', lastModified: DATES.seoOverhaul },
     { path: '/private-hire/gender-reveal', lastModified: DATES.seoOverhaul },
     { path: '/private-hire/milestone-birthdays', lastModified: DATES.seoOverhaul },
@@ -294,21 +291,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const eventDate = Date.parse(event.startDate)
       const daysSince = (nowMs - eventDate) / (1000 * 60 * 60 * 24)
 
-      // Past events stay listed. They remain live and indexed, so excluding
-      // them from the sitemap would just slow down how often Google recrawls
-      // the very pages this policy exists to let accumulate.
-
-      // Formats the SSOT says are discontinued are noindex, so they must not
-      // be listed here either.
-      if (isDiscontinuedFormatEvent(event)) return false
-
-      // Cancelled events are the exception: nothing happened, so there is no
-      // content worth ranking, and they go noindex after 7 days.
-      const status = event.event_status || event.eventStatus || ''
-      const isCancelled = status.toLowerCase().includes('cancelled')
-      if (isCancelled && daysSince > CANCELLED_INDEX_DAYS) return false
-
-      return true
+      // One rule, one place. getEventSeoStrategy decides indexability for the
+      // page head and the page body; the sitemap must not carry its own copy of
+      // it, or the two drift and we list pages we are telling Google to ignore.
+      //
+      // Caveat: this runs on the events LIST payload, which is a lighter
+      // projection than the detail record. It omits long_description, so a
+      // banned claim living only there is invisible here and the URL can still
+      // be listed. The page itself fetches the detail record and returns
+      // noindex, which is authoritative, so the URL drops out on crawl rather
+      // than never being listed. Fetching 55 detail records to build a sitemap
+      // is not worth that tidiness.
+      //
+      // Past events stay listed: they remain live and indexed, so excluding
+      // them would only slow how often Google recrawls the very pages this
+      // policy exists to let accumulate.
+      return getEventSeoStrategy(event).index
     })
     .map((event) => ({
       url: `${baseUrl}${getEventWebsitePath(event)}`,

--- a/app/whats-on/page.tsx
+++ b/app/whats-on/page.tsx
@@ -299,7 +299,7 @@ export default async function WhatsOnPage() {
             <SectionHeading
               kicker="Recent events"
               title="From the recent event archive"
-              lead="Recently finished event pages stay linked here while the next dates are promoted."
+              lead="A look back at recent nights. Every event page stays online, so you can see what one of our nights is actually like before booking the next."
             />
 
             <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/components/tracking/EventPageTracker.tsx
+++ b/components/tracking/EventPageTracker.tsx
@@ -9,16 +9,34 @@ interface EventPageTrackerProps {
   eventDate: string
   eventCategory?: string
   eventPrice?: number
+  /** True once the night has happened. Suppresses the ecommerce signals. */
+  hasEnded?: boolean
 }
 
-export function EventPageTracker({ 
-  eventId, 
-  eventName, 
-  eventDate, 
+export function EventPageTracker({
+  eventId,
+  eventName,
+  eventDate,
   eventCategory,
-  eventPrice 
+  eventPrice,
+  hasEnded = false
 }: EventPageTrackerProps) {
   useEffect(() => {
+    // Past event pages stay live and indexed, so they now take real traffic.
+    // Firing view_item with a price on a night nobody can book pollutes the
+    // ecommerce funnel and feeds junk into remarketing audiences: the visitor
+    // showed no purchase intent, because there is nothing to purchase.
+    if (hasEnded) {
+      trackEventDetailImpression({
+        eventId,
+        eventName,
+        eventDate,
+        eventCategory,
+        source: 'event_detail_page_archived'
+      })
+      return
+    }
+
     // Track event view for remarketing and analytics
     trackEventView({
       eventId,
@@ -27,7 +45,7 @@ export function EventPageTracker({
       eventCategory,
       eventPrice
     })
-    
+
     trackViewItem({ category: 'event', name: eventName, id: eventId })
     trackEventDetailImpression({
       eventId,
@@ -37,7 +55,7 @@ export function EventPageTracker({
       eventPrice,
       source: 'event_detail_page'
     })
-  }, [eventId, eventName, eventDate, eventCategory, eventPrice])
-  
+  }, [eventId, eventName, eventDate, eventCategory, eventPrice, hasEnded])
+
   return null
 }

--- a/lib/event-copy.ts
+++ b/lib/event-copy.ts
@@ -1,0 +1,110 @@
+import type { Event } from '@/lib/api'
+import { formatEventLocalDate } from '@/lib/event-calendar'
+import { getEventPresentation } from '@/lib/event-presentation'
+
+/**
+ * Copy for an event page, in the right tense.
+ *
+ * Past event pages are kept live and indexed so their content can accumulate
+ * (see tasks/gsc-indexing-fix/url-lifecycle-policy.md §1). That only works if
+ * the page reads as a record of a night that happened. The promotional
+ * description written to sell tickets is future tense, so inheriting it on a
+ * past page produces a search result that says "Book your tickets now!" for a
+ * date months gone.
+ *
+ * The page body, the head, the Open Graph card and the JSON-LD all resolve
+ * their copy here, so they cannot drift into different tenses.
+ */
+
+/**
+ * Questions that only make sense while a night is still bookable.
+ *
+ * Matched against the question text only, never the answer. Almost every answer
+ * mentions a price or the word "book" somewhere, so matching answers too would
+ * strip the whole FAQ block, and the FAQs are often the only unique prose on an
+ * event page. Past pages are kept precisely so that content can accumulate, so
+ * "what time do doors open" and "is it dog friendly" must survive.
+ */
+const BOOKING_QUESTION_PATTERN =
+  /\b(book|booking|reserve|reservation|deposit|refund|cancel|cancellation|pay|payment|sold\s*out|still\s+available|get\s+tickets|buy)\b/i
+
+type FaqLike = { name: string; acceptedAnswer: { text: string } }
+
+/**
+ * FAQs to show on an event page. Ended events keep everything except the
+ * questions about booking a night that has already happened.
+ */
+export function getDisplayableFaqs<T extends FaqLike>(faqs: T[], hasEnded: boolean): T[] {
+  if (!hasEnded) return faqs
+  return faqs.filter((faq) => !BOOKING_QUESTION_PATTERN.test(faq.name || ''))
+}
+
+function eventDateLabel(event: Pick<Event, 'startDate'>): string {
+  return (
+    formatEventLocalDate(event.startDate, {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric'
+    }) || ''
+  )
+}
+
+/**
+ * Meta description for the page head and the Open Graph card.
+ *
+ * An ended event never inherits `metaDescription` / `shortDescription`, because
+ * those are sales copy. It gets a factual past-tense line instead.
+ */
+export function getEventMetaDescription(
+  event: Pick<
+    Event,
+    'name' | 'startDate' | 'event_status' | 'eventStatus' | 'category' | 'metaDescription' | 'shortDescription' | 'description' | 'bookings_enabled' | 'booking_cutoff_at'
+  >,
+  liveFallback: string
+): string {
+  const { hasEnded } = getEventPresentation(event)
+  if (!hasEnded) {
+    return event.metaDescription || event.shortDescription || event.description || liveFallback
+  }
+
+  const date = eventDateLabel(event)
+  const categoryName = event.category?.name
+  const onward = categoryName
+    ? ` See upcoming ${categoryName} dates at The Anchor.`
+    : ' See what is coming up at The Anchor.'
+
+  return `${event.name} took place at The Anchor in Stanwell Moor${date ? ` on ${date}` : ''}.${onward}`
+}
+
+/**
+ * Description for the Event JSON-LD.
+ *
+ * `description` is a recommended Event property, so this must stay non-empty.
+ * It simply must not invite anyone to a night that has already happened.
+ */
+export function getEventSchemaDescription(
+  event: Pick<
+    Event,
+    'name' | 'startDate' | 'event_status' | 'eventStatus' | 'category' | 'longDescription' | 'about' | 'description' | 'shortDescription' | 'bookings_enabled' | 'booking_cutoff_at'
+  >
+): string {
+  const { hasEnded } = getEventPresentation(event)
+  const stored =
+    event.longDescription || event.about || event.description || event.shortDescription
+
+  // Stored copy is kept on an upcoming event, and on an ended one only when it
+  // does not read as an invitation. "Get ready for a massive night" on a night
+  // eight weeks gone is the same defect as the meta description had.
+  const readsAsInvitation =
+    /\b(get ready|join us|book (your|now|online)|don'?t miss|grab your|secure your|coming up|this (friday|saturday|sunday|monday|tuesday|wednesday|thursday))\b/i
+
+  if (stored && !(hasEnded && readsAsInvitation.test(stored))) return stored
+
+  if (hasEnded) {
+    const date = eventDateLabel(event)
+    return `${event.name} took place at The Anchor in Stanwell Moor${date ? ` on ${date}` : ''}.`
+  }
+
+  return `Join us for ${event.name} at The Anchor in Stanwell Moor. Experience great food, drinks and entertainment in a welcoming atmosphere.`
+}

--- a/lib/event-seo-strategy.ts
+++ b/lib/event-seo-strategy.ts
@@ -48,16 +48,129 @@ const DISCONTINUED_FORMATS: ReadonlyArray<{
   },
 ]
 
-function discontinuedHaystack(event: Partial<Pick<Event, 'name' | 'slug'>>): string {
-  return `${event.name ?? ''} ${event.slug ?? ''}`
+/**
+ * Claims docs/SSOT.md §14 verifies as factually false about the venue.
+ *
+ * Keeping past events indexed means event copy written months ago now competes
+ * in search indefinitely. Several past events carry facility claims the SSOT
+ * marks "verified NO", so this guard keeps those pages out of the index until
+ * the copy is corrected in the management app.
+ *
+ * Deliberately narrow: only unambiguous, verified-false statements of fact,
+ * where a false positive merely costs one page its ranking. Judgement calls
+ * such as unsubstantiated "best" superlatives, retired roast pre-order wording
+ * and forward-looking mulled wine are NOT here. They need a human editing the
+ * source copy, and over-broad pattern matching would quietly deindex good
+ * pages. (The SSOT expressly permits a historical mulled wine mention in a
+ * dated recap, which is exactly what a past event page is.)
+ *
+ * This is a safety net, not a fix. The copy lives in the management database.
+ */
+const BANNED_FACTUAL_CLAIMS: ReadonlyArray<{ pattern: RegExp; claim: string }> = [
+  { pattern: /accessible\s+toilet/i, claim: 'accessible toilet (SSOT: verified NO)' },
+  { pattern: /\bgluten[-\s]?free\b/i, claim: 'gluten-free (SSOT: regulated term, use NGCI)' },
+  { pattern: /baby[-\s]?changing/i, claim: 'baby changing (SSOT: verified NO)' },
+  { pattern: /air[-\s]?condition(ed|ing)|climate[-\s]?controlled/i, claim: 'air conditioning (SSOT: verified NO)' },
+  { pattern: /wedding\s+reception/i, claim: 'wedding receptions (SSOT: not offered)' },
+  { pattern: /champions\s+league/i, claim: 'Champions League (SSOT: cannot show, no Sky/TNT)' },
+  { pattern: /\b(sky|tnt)\s+sports\b/i, claim: 'Sky/TNT Sports (SSOT: terrestrial only)' },
+]
+
+type BannedClaimFields = Partial<
+  Pick<Event, 'name' | 'description' | 'shortDescription' | 'longDescription' | 'about' | 'highlights'>
+>
+
+/**
+ * Deliberately excludes `accessibility_notes`.
+ *
+ * That field is populated from the event-category template in the management
+ * app, and the template currently asserts an accessible toilet, which the SSOT
+ * verifies as NO. Because it is a template, the string is on upcoming events
+ * too, so treating it as a noindex trigger would deindex the pub's live
+ * listings, which is a worse outcome than the claim itself.
+ *
+ * A single structured field can simply be withheld instead. See
+ * getSafeAccessibilityNotes below. Prose fields cannot: a banned claim woven
+ * into a paragraph cannot be safely rewritten by a regex, so those do trigger
+ * noindex until a human corrects the copy at source.
+ */
+function bannedClaimHaystack(event: BannedClaimFields): string {
+  return [
+    event.name,
+    event.description,
+    event.shortDescription,
+    event.longDescription,
+    event.about,
+    Array.isArray(event.highlights) ? event.highlights.join(' ') : '',
+  ]
+    .filter((v): v is string => typeof v === 'string')
+    .join(' ')
+}
+
+/**
+ * Accessibility notes to display, or null when they carry a claim the SSOT
+ * verifies as false.
+ *
+ * Withholding beats rendering here. A wrong accessibility statement is worse
+ * than no statement: someone with mobility needs could plan a visit around it.
+ * The /find-us page and a phone call remain the accurate route.
+ */
+export function getSafeAccessibilityNotes(
+  event: Partial<Pick<Event, 'accessibility_notes'>>
+): string | null {
+  const notes = typeof event.accessibility_notes === 'string' ? event.accessibility_notes.trim() : ''
+  if (!notes) return null
+  const carriesBannedClaim = BANNED_FACTUAL_CLAIMS.some(({ pattern }) => pattern.test(notes))
+  return carriesBannedClaim ? null : notes
+}
+
+/** Which banned claims an event's copy contains. Empty when it is clean. */
+export function getBannedClaims(event: BannedClaimFields): string[] {
+  const haystack = bannedClaimHaystack(event)
+  if (!haystack.trim()) return []
+  return BANNED_FACTUAL_CLAIMS.filter(({ pattern }) => pattern.test(haystack)).map(
+    ({ claim }) => claim,
+  )
+}
+
+export function hasBannedClaim(event: BannedClaimFields): boolean {
+  return getBannedClaims(event).length > 0
+}
+
+type DiscontinuedFields = Partial<
+  Pick<Event, 'name' | 'slug' | 'description' | 'shortDescription' | 'keywords' | 'highlights' | 'category'>
+>
+
+function flattenText(value: unknown): string {
+  if (Array.isArray(value)) return value.join(' ')
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * The format signal is not always in the title. "Sleigh That Tune" is a Nikki
+ * games night with no giveaway in its name or slug, so a name-only check
+ * shipped it straight into the index. Category, keywords, highlights and the
+ * descriptions all carry the signal in practice.
+ */
+function discontinuedHaystack(event: DiscontinuedFields): string {
+  return [
+    event.name,
+    event.slug,
+    event.description,
+    event.shortDescription,
+    flattenText(event.keywords),
+    flattenText(event.highlights),
+    event.category?.name,
+    event.category?.slug,
+  ]
+    .map(flattenText)
+    .join(' ')
     .toLowerCase()
     .replace(/[-_]+/g, ' ')
     .replace(/\s+/g, ' ')
 }
 
-export function isDiscontinuedFormatEvent(
-  event: Partial<Pick<Event, 'name' | 'slug'>>
-): boolean {
+export function isDiscontinuedFormatEvent(event: DiscontinuedFields): boolean {
   const haystack = discontinuedHaystack(event)
   return DISCONTINUED_FORMATS.some((format) => haystack.includes(format.token))
 }
@@ -71,7 +184,7 @@ export function isDiscontinuedFormatEvent(
  * listing. Music Bingo is the format she actually hosts now.
  */
 export function getDiscontinuedFormatReplacement(
-  event: Partial<Pick<Event, 'name' | 'slug'>>
+  event: DiscontinuedFields
 ): { href: string; label: string; copy: string } | null {
   const haystack = discontinuedHaystack(event)
   const match = DISCONTINUED_FORMATS.find((format) => haystack.includes(format.token))
@@ -130,14 +243,17 @@ export interface EventSeoStrategy {
  */
 export function getEventSeoStrategy(
   event: Pick<Event, 'startDate' | 'event_status' | 'eventStatus' | 'category'> &
-    Partial<Pick<Event, 'name' | 'slug'>>
+    DiscontinuedFields &
+    BannedClaimFields
 ): EventSeoStrategy {
   const status = normalizeEventStatus(event)
   const isPast = isEventInPast(event)
 
-  // Discontinued formats stay reachable but out of search, whatever their date.
-  // Keeping them indexed would rank a night nobody can attend.
-  if (isDiscontinuedFormatEvent(event)) {
+  // Discontinued formats, and any event whose copy carries a claim the SSOT
+  // verifies as false, stay reachable but out of search whatever their date.
+  // Keeping them indexed would rank a night nobody can attend, or advertise
+  // facilities the pub does not have.
+  if (isDiscontinuedFormatEvent(event) || hasBannedClaim(event)) {
     return {
       index: false,
       showEndedBanner: isPast,

--- a/lib/structured-data/event-schema.ts
+++ b/lib/structured-data/event-schema.ts
@@ -2,8 +2,9 @@ import { Event, getEventTicketTypes, hasMultipleTicketPrices } from '@/lib/api'
 import { getEventDateRangeUtc } from '@/lib/event-calendar'
 import { DEFAULT_EVENT_IMAGE } from '@/lib/image-fallbacks'
 import { getEventWebsiteUrl } from '@/lib/event-url'
-import { getSchemaEventStatus, getSchemaOfferAvailability, CATEGORY_ROUTES } from '@/lib/event-seo-strategy'
+import { getSchemaEventStatus, getSchemaOfferAvailability, getSafeAccessibilityNotes, CATEGORY_ROUTES } from '@/lib/event-seo-strategy'
 import { getEventPresentation } from '@/lib/event-presentation'
+import { getEventSchemaDescription } from '@/lib/event-copy'
 
 
 const SITE_ORIGIN = 'https://www.the-anchor.pub'
@@ -149,12 +150,7 @@ export function buildEventSchema(event: Event) {
     '@id': eventUrl,
     identifier: event.identifier || event.id,
     name: event.name,
-    description:
-      event.longDescription ||
-      event.about ||
-      event.description ||
-      event.shortDescription ||
-      `Join us for ${event.name} at The Anchor in Stanwell Moor. Experience great food, drinks and entertainment in a welcoming atmosphere.`,
+    description: getEventSchemaDescription(event),
     ...(event.shortDescription && { disambiguatingDescription: event.shortDescription }),
     ...(event.keywords && {
       keywords: Array.isArray(event.keywords) ? event.keywords.join(', ') : event.keywords
@@ -241,8 +237,11 @@ export function buildEventSchema(event: Event) {
   }
 
   // Conditionally add accessibility feature from event data
-  if (event.accessibility_notes) {
-    schema.accessibilityFeature = [event.accessibility_notes]
+  // Same suppression as the visible page: never assert an accessibility
+  // feature the SSOT verifies we do not have.
+  const safeAccessibilityNotes = getSafeAccessibilityNotes(event)
+  if (safeAccessibilityNotes) {
+    schema.accessibilityFeature = [safeAccessibilityNotes]
   }
 
   return schema

--- a/tests/event-copy.test.ts
+++ b/tests/event-copy.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Past event pages are kept live and indexed so their content can accumulate.
+ * That only works if they read as a record of a night that happened.
+ *
+ * Before this, 39 of 58 live past pages served the promotional description
+ * verbatim, so a search result for a night in June invited people to book it.
+ */
+
+import {
+  getEventMetaDescription,
+  getEventSchemaDescription,
+  getDisplayableFaqs,
+} from '@/lib/event-copy'
+import type { Event } from '@/lib/api'
+
+const DAY = 24 * 60 * 60 * 1000
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'e1',
+    name: 'Music Bingo',
+    slug: 'music-bingo-test',
+    startDate: new Date(Date.now() + 7 * DAY).toISOString(),
+    event_status: 'scheduled',
+    eventStatus: 'scheduled',
+    category: { id: 'c1', slug: 'music-bingo', name: 'Music Bingo', color: '#000' },
+    ...overrides,
+  } as Event
+}
+
+const SALES_COPY = 'Book your tickets now! Do not miss the biggest night of the month.'
+
+describe('getEventMetaDescription', () => {
+  it('uses the stored sales copy while the event is upcoming', () => {
+    const d = getEventMetaDescription(makeEvent({ metaDescription: SALES_COPY }), 'fallback')
+    expect(d).toBe(SALES_COPY)
+  })
+
+  it('never reuses sales copy once the event has ended', () => {
+    const d = getEventMetaDescription(
+      makeEvent({ startDate: new Date(Date.now() - 30 * DAY).toISOString(), metaDescription: SALES_COPY }),
+      'fallback',
+    )
+    expect(d).not.toContain('Book your tickets')
+    expect(d).not.toBe(SALES_COPY)
+  })
+
+  it('states the event took place, and points at the category', () => {
+    const d = getEventMetaDescription(
+      makeEvent({ startDate: new Date(Date.now() - 30 * DAY).toISOString() }),
+      'fallback',
+    )
+    expect(d).toContain('Music Bingo took place at The Anchor')
+    expect(d).toContain('See upcoming Music Bingo dates')
+  })
+
+  it('does not invite anyone to join us on a past night', () => {
+    const d = getEventMetaDescription(
+      makeEvent({ startDate: new Date(Date.now() - 400 * DAY).toISOString() }),
+      'Join us for Music Bingo at The Anchor.',
+    )
+    expect(d.toLowerCase()).not.toContain('join us')
+  })
+})
+
+describe('getEventSchemaDescription', () => {
+  it('keeps the stored description when there is one', () => {
+    const d = getEventSchemaDescription(makeEvent({ longDescription: 'A long description.' }))
+    expect(d).toBe('A long description.')
+  })
+
+  it('falls back to past tense on an ended event with no stored copy', () => {
+    const d = getEventSchemaDescription(
+      makeEvent({ startDate: new Date(Date.now() - 10 * DAY).toISOString() }),
+    )
+    expect(d).toContain('took place')
+    expect(d.toLowerCase()).not.toContain('join us')
+  })
+
+  it('falls back to future tense on an upcoming event with no stored copy', () => {
+    const d = getEventSchemaDescription(makeEvent())
+    expect(d).toContain('Join us for')
+  })
+
+  it('is never empty, since description is a recommended Event property', () => {
+    expect(getEventSchemaDescription(makeEvent()).length).toBeGreaterThan(0)
+    expect(
+      getEventSchemaDescription(makeEvent({ startDate: new Date(Date.now() - 5 * DAY).toISOString() })).length,
+    ).toBeGreaterThan(0)
+  })
+})
+
+describe('getDisplayableFaqs', () => {
+  const faqs = [
+    { name: 'Do I need to book?', acceptedAnswer: { text: 'Yes, book online.' } },
+    { name: 'What time do doors open?', acceptedAnswer: { text: 'Doors at 6pm, tickets £5.' } },
+    { name: 'Is the pub dog friendly?', acceptedAnswer: { text: 'Yes, dogs are welcome.' } },
+    { name: 'Can I get a refund?', acceptedAnswer: { text: 'Contact us.' } },
+  ]
+
+  it('keeps every FAQ on an upcoming event', () => {
+    expect(getDisplayableFaqs(faqs, false)).toHaveLength(4)
+  })
+
+  it('drops booking questions once the event has ended', () => {
+    const kept = getDisplayableFaqs(faqs, true).map((f) => f.name)
+    expect(kept).not.toContain('Do I need to book?')
+    expect(kept).not.toContain('Can I get a refund?')
+  })
+
+  it('keeps the non-booking questions, which are often the only unique prose', () => {
+    const kept = getDisplayableFaqs(faqs, true).map((f) => f.name)
+    expect(kept).toContain('What time do doors open?')
+    expect(kept).toContain('Is the pub dog friendly?')
+  })
+
+  it('matches on the question only, so an answer mentioning price survives', () => {
+    // "Doors at 6pm, tickets £5" mentions tickets, but the question is about
+    // doors. Matching answers too would strip almost the whole block.
+    const kept = getDisplayableFaqs(faqs, true)
+    expect(kept.some((f) => f.acceptedAnswer.text.includes('tickets'))).toBe(true)
+  })
+})

--- a/tests/event-seo-strategy.test.ts
+++ b/tests/event-seo-strategy.test.ts
@@ -16,6 +16,7 @@
 
 import {
   getEventSeoStrategy,
+  getBannedClaims,
   getDiscontinuedFormatReplacement,
   RECENT_EVENT_WINDOW_DAYS,
   CANCELLED_INDEX_DAYS,
@@ -182,6 +183,86 @@ describe('getEventSeoStrategy', () => {
       }) as unknown as Record<string, unknown>
       expect(result.redirect).toBeUndefined()
       expect(result.showEndedBanner).toBe(true)
+    })
+  })
+
+  describe('SSOT banned claims', () => {
+    // Keeping past events indexed means copy written months ago competes in
+    // search indefinitely. docs/SSOT.md §14 verifies these as false.
+    it.each([
+      ['accessible toilet', 'We have an accessible toilet on site.'],
+      ['gluten-free', 'Gluten-free options available on request.'],
+      ['baby changing', 'Baby changing facilities available.'],
+      ['air conditioning', 'Enjoy our air conditioned function room.'],
+      ['wedding receptions', 'Perfect for your wedding reception.'],
+      ['Champions League', 'Watch the Champions League with us.'],
+    ])('noindexes an event whose copy claims %s', (_label, description) => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(20),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Quiz Night',
+        description,
+      })
+      expect(result.index).toBe(false)
+    })
+
+    it('reports which claim was found, so the copy can be corrected at source', () => {
+      const claims = getBannedClaims({
+        name: 'Tasting Night',
+        description: 'Gluten-free options and an accessible toilet.',
+      })
+      expect(claims).toHaveLength(2)
+      expect(claims.join(' ')).toContain('gluten-free')
+      expect(claims.join(' ')).toContain('accessible toilet')
+    })
+
+    it('leaves clean copy indexed', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(20),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Quiz Night',
+        description: 'Four rounds of trivia, teams up to six, £3 per person.',
+      })
+      expect(result.index).toBe(true)
+      expect(getBannedClaims({ description: 'Four rounds of trivia.' })).toEqual([])
+    })
+
+    it('keeps the page live, it is noindex not a redirect or a 404', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(20),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Quiz Night',
+        description: 'We have an accessible toilet.',
+      }) as unknown as Record<string, unknown>
+      expect(result.redirect).toBeUndefined()
+    })
+  })
+
+  describe('discontinued formats hidden outside the title', () => {
+    it('catches a games night named "Sleigh That Tune" via its description', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(200),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Sleigh That Tune',
+        slug: 'sleigh-that-tune-2025-12-18',
+        description: "Nikki's games night, festive edition.",
+      })
+      expect(result.index).toBe(false)
+    })
+
+    it('catches it via category name when the copy is silent', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(200),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Sleigh That Tune',
+        category: { id: 'c9', slug: 'games-night', name: 'Games Night', color: '#000' },
+      })
+      expect(result.index).toBe(false)
     })
   })
 


### PR DESCRIPTION
## What changed

A follow-up audit of #84, which kept past event pages live and indexed. Publishing 52 previously-hidden pages surfaced problems that were harmless while those pages were `noindex` and are not any more.

**Tense.** `generateMetadata` had no past-event branch, so 39 of 58 live past pages served their promotional copy verbatim. A search result for a night in June read "Book your tickets now!". The head description, Open Graph, Twitter card and JSON-LD description now all resolve through `lib/event-copy.ts`, which refuses to reuse sales copy once a night has passed. The OG image drops the price and start time and says "Event ended".

**SSOT.** Seven events assert an **accessible toilet**, which `docs/SSOT.md` verifies we do NOT have. It comes from the event-category template, so it is on upcoming events too. That field is now withheld whenever it carries a verified-false claim, in both the page and the schema.

Withholding beats deindexing here, and the distinction matters: my first attempt treated any banned claim as a noindex trigger, which deindexed the pub's **live** listings because the template string is on them as well. A single structured field can simply be withheld. Prose cannot, so where a banned claim is woven into a paragraph the page goes `noindex` instead. One event qualifies today.

**Discontinued formats.** `isDiscontinuedFormatEvent` scanned name and slug only, so "Sleigh That Tune" shipped the discontinued Nikki games-night format into the index under a name that gives nothing away. It now reads category, keywords, highlights and descriptions too.

**Also:** past sold-out nights offered to check for cancellations; the hero status badge contradicted the deliberately hidden status row; hiding every FAQ stripped the only unique prose from 17 of the 58 pages kept alive to accumulate content; `view_item` fired with a price on unbookable nights; three sitemap entries reported a fresh `lastmod` every hour because they were pinned to `new Date()`; and indexability lived in three places, which is now one.

## Why

The audit was run precisely because #84 changed what is exposed. Most of these were latent for months, and #84 is what made them matter.

## Testing done

- [x] Automated: 1334 passing, 124 suites. New `tests/event-copy.test.ts`; `tests/event-seo-strategy.test.ts` extended with banned-claim and hidden-format cases.
- [x] Verified against the live management API on a dev server, not just fixtures:

| | upcoming | past (55d) |
|---|---|---|
| robots | `index, follow` | `index, follow` |
| description | future tense | "took place at The Anchor on Friday, 12 June 2026" |
| JSON-LD description | future tense | past tense |
| JSON-LD offers | present | absent |
| accessible toilet | suppressed | suppressed |
| booking surfaces | intact | none |

- [x] Scanned all 58 live events' detail records: exactly 1 has a banned claim in prose (noindexed), 7 have one only in `accessibility_notes` (field suppressed, page stays indexed). No false positives on the correct NGCI wording.
- [x] Sitemap: 55 event URLs, games-night and "Sleigh That Tune" excluded, no rolling `lastmod`.
- [x] `tsc` clean, lint clean, production build compiles.

## Assumptions

- Withholding a false accessibility claim is better than deindexing the page. A wrong accessibility statement could have someone plan a visit around it; `/find-us` and a phone call remain accurate.
- The FAQ filter matches question text only. Matching answers too would strip nearly the whole block, since most answers mention a price.
- The sitemap runs on the events list payload, which omits `long_description`, so a banned claim living only there is invisible to it. The page returns `noindex` and that is authoritative. Documented in `app/sitemap.ts` rather than fetching 55 detail records to build a sitemap.

## Still needs a human, not code

The copy lives in the management database. These guards stop it ranking; they do not fix it. See the PR discussion for the list.

## Complexity score

M

## Breaking changes

None.

## Migration risk

Low. One past event goes `noindex`; everything else keeps its current indexability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)