### PR TITLE
fix(tests): pin the availability contract clock to its own fixture

### DIFF
--- a/tests/api/table-availability-contract.test.ts
+++ b/tests/api/table-availability-contract.test.ts
@@ -65,12 +65,29 @@ describe('availability contract (website side)', () => {
   let getAvailability: (request: Request) => Promise<Response>
 
   beforeEach(async () => {
+    // The fixture is a capture of one moment, and it records that moment as
+    // `scenario.now`. Pin the clock to it.
+    //
+    // Without this the suite is a time bomb. `scenario.date` is 2026-08-07,
+    // and the availability route applies a same-day cutoff when the requested
+    // date equals London-today: app/api/table-bookings/availability/route.ts
+    // drops every slot less than an hour out. So on 2026-08-07 itself, from
+    // roughly 17:00 London, the 18:00 and 20:00 slots these tests assert on
+    // simply vanish and three tests go red, for reasons that have nothing to
+    // do with the contract being tested.
+    //
+    // Deriving the time from the fixture rather than repeating a literal means
+    // the pin cannot drift when the fixture is next recaptured.
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'queueMicrotask'] })
+    jest.setSystemTime(new Date(contract.scenario.now))
+
     mockGetBusinessHours.mockResolvedValue(FRIDAY_HOURS)
     jest.resetModules()
     ;({ GET: getAvailability } = await import('@/app/api/table-bookings/availability/route'))
   })
 
   afterEach(() => {
+    jest.useRealTimers()
     jest.clearAllMocks()
   })
 
@@ -80,7 +97,7 @@ describe('availability contract (website side)', () => {
   // fixture answers both calls: the drinks answer drives availability and the
   // food answer drives only the kitchen_open label. The two-call behaviour
   // itself is covered in table-bookings-availability-combined.test.ts.
-  async function fetchWith(load: unknown, query = 'date=2026-08-07&party_size=4') {
+  async function fetchWith(load: unknown, query = `date=${contract.scenario.date}&party_size=4`) {
     mockGetTableBookingLoadSafe.mockResolvedValue(load)
     const response = await getAvailability(
       new Request(`https://www.the-anchor.pub/api/table-bookings/availability?${query}`)
@@ -282,14 +299,14 @@ describe('availability contract (website side)', () => {
         loadWith({
           contract_version: 1,
           calculation_state: 'complete',
-          date: '2026-08-07',
+          date: contract.scenario.date,
           party_size: 30,
           slots: [],
           public_reason: 'too_large',
           message: 'For parties that size, please give us a ring on 01753 682707.',
           max_party_size_online: 20
         }),
-        'date=2026-08-07&party_size=30'
+        `date=${contract.scenario.date}&party_size=30`
       )
 
       expect(body.data.time_slots).toEqual([])

--- a/tests/unit/ManagementTableBookingForm.test.tsx
+++ b/tests/unit/ManagementTableBookingForm.test.tsx
@@ -6,10 +6,14 @@ import {
 } from '@/lib/booking-attribution'
 
 /**
- * Held relative to whenever the suite runs. This was the literal
- * '2026-07-10T11:30:00.000Z', which would have aged past the 90 day
- * ATTRIBUTION_TTL_DAYS window in October 2026 and started dropping the UTM
- * fields this test asserts on.
+ * Capture time for the attribution assertions below.
+ *
+ * Unlike ManagementEventBookingForm.test.tsx and booking-attribution.test.ts,
+ * this suite already freezes Date at FROZEN_NOW, so the 90 day
+ * ATTRIBUTION_TTL_DAYS check is measured against that fixed point rather than
+ * the wall clock. The previous literal '2026-07-10T11:30:00.000Z' was never
+ * going to expire here. Kept relative only so the value stops reading like a
+ * date somebody has to maintain.
  */
 const ATTRIBUTION_CAPTURED_AT = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
 


### PR DESCRIPTION
## What changed

`tests/api/table-availability-contract.test.ts` now pins the clock to the moment its fixture was captured, and derives its request dates from the fixture instead of repeating a literal.

## Why

The fixture's date is **2026-08-07, which is today**. The availability route applies a same-day cutoff: when the requested date equals London-today it drops every slot less than an hour out. From roughly **17:00 London this evening** the 18:00 and 20:00 slots these tests assert on vanish, and three tests go red:

- marks available slots bookable and unavailable slots not, carrying the reason through
- a website slot the picker did not speak about is not bookable
- tolerates every informational echo being absent

Verified empirically against HEAD at simulated clock offsets: passes at +7h, fails at +8h through +14h, passes again at +16h once the date rolls into the past and the same-day filter switches off. It would have looked like a booking regression rather than an expired fixture.

The fixture already records its capture moment as `scenario.now`, so that is what the clock pins to. Deriving from the fixture rather than a second literal means the pin cannot drift when the fixture is recaptured.

## Testing done

- [x] 11/11 pass in this suite; 1334 passing across 124 suites.
- [x] AMS mirror (`src/app/api/table-bookings/__tests__/table-availability-contract.test.ts`) given the same pin, 6 passing there.
- [x] `tsc` clean, lint clean.

## Assumptions

- The AMS side is less exposed than the website side, since its route has no same-day cutoff. Pinned anyway because the two files are deliberate mirrors of one contract.

## Correction included

A comment I added in 455fa6dc claimed the attribution fixture in `ManagementTableBookingForm.test.tsx` was a time bomb that would fire in October. It was not: that suite freezes `Date` at `FROZEN_NOW`, so its TTL check never reaches the wall clock. The code change was harmless, but the note was wrong and would have sent the next reader "fixing" suites that are already correct. Comment corrected.

The two genuine bombs in that commit, `ManagementEventBookingForm.test.tsx` and `booking-attribution.test.ts`, neither of which pins the clock, were real.

## Complexity score

XS

## Breaking changes

None. Tests only.

## Migration risk

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)