### PR TITLE
fix(events): show accessibility notes that deny a facility, not just ones that omit it

### DIFF
--- a/lib/event-seo-strategy.ts
+++ b/lib/event-seo-strategy.ts
@@ -108,6 +108,27 @@ function bannedClaimHaystack(event: BannedClaimFields): string {
 }
 
 /**
+ * True when the matched phrase is being denied rather than asserted.
+ *
+ * The corrected accessibility copy reads "We do not currently have an
+ * accessible toilet", which contains the banned phrase while saying exactly the
+ * right thing. Suppressing that would hide the honest statement and leave
+ * visitors with nothing, which is the opposite of the point. Only an
+ * unqualified assertion should be withheld.
+ */
+function isNegatedClaim(text: string, pattern: RegExp): boolean {
+  const match = pattern.exec(text)
+  if (!match) return false
+  // Look back over the words immediately before the phrase, not the whole
+  // string: "we have an accessible toilet, but no baby changing" must not read
+  // as a denial of the toilet.
+  const preceding = text.slice(Math.max(0, match.index - 60), match.index)
+  return /\b(no|not|don'?t|doesn'?t|without|lack|lacks|unable to offer|cannot offer)\b[^.!?]*$/i.test(
+    preceding,
+  )
+}
+
+/**
  * Accessibility notes to display, or null when they carry a claim the SSOT
  * verifies as false.
  *
@@ -120,7 +141,9 @@ export function getSafeAccessibilityNotes(
 ): string | null {
   const notes = typeof event.accessibility_notes === 'string' ? event.accessibility_notes.trim() : ''
   if (!notes) return null
-  const carriesBannedClaim = BANNED_FACTUAL_CLAIMS.some(({ pattern }) => pattern.test(notes))
+  const carriesBannedClaim = BANNED_FACTUAL_CLAIMS.some(
+    ({ pattern }) => pattern.test(notes) && !isNegatedClaim(notes, pattern),
+  )
   return carriesBannedClaim ? null : notes
 }
 

--- a/tests/event-seo-strategy.test.ts
+++ b/tests/event-seo-strategy.test.ts
@@ -17,6 +17,7 @@
 import {
   getEventSeoStrategy,
   getBannedClaims,
+  getSafeAccessibilityNotes,
   getDiscontinuedFormatReplacement,
   RECENT_EVENT_WINDOW_DAYS,
   CANCELLED_INDEX_DAYS,
@@ -238,6 +239,46 @@ describe('getEventSeoStrategy', () => {
         description: 'We have an accessible toilet.',
       }) as unknown as Record<string, unknown>
       expect(result.redirect).toBeUndefined()
+    })
+  })
+
+  describe('accessibility notes', () => {
+    // The event-category template asserts an accessible toilet; the SSOT says
+    // we do not have one. That single field is withheld rather than the page
+    // being deindexed, because the same string is on upcoming events too.
+    it('withholds notes that assert a facility we do not have', () => {
+      expect(
+        getSafeAccessibilityNotes({
+          accessibility_notes:
+            'The Anchor offers step-free access throughout the ground floor with an accessible toilet.',
+        }),
+      ).toBeNull()
+    })
+
+    it('keeps the corrected notes, which deny the same facility', () => {
+      // The honest wording contains the banned phrase while saying the right
+      // thing. Suppressing it would leave visitors with nothing at all.
+      const corrected =
+        'The bar and dining area are step-free from the level car park. We do not currently have an accessible toilet. Please call 01753 682707 to discuss specific access needs.'
+      expect(getSafeAccessibilityNotes({ accessibility_notes: corrected })).toBe(corrected)
+    })
+
+    it('still withholds an assertion that sits alongside an unrelated denial', () => {
+      expect(
+        getSafeAccessibilityNotes({
+          accessibility_notes: 'We have an accessible toilet, but no baby changing facilities.',
+        }),
+      ).toBeNull()
+    })
+
+    it('returns null for empty or missing notes', () => {
+      expect(getSafeAccessibilityNotes({ accessibility_notes: '  ' })).toBeNull()
+      expect(getSafeAccessibilityNotes({})).toBeNull()
+    })
+
+    it('keeps ordinary notes untouched', () => {
+      const plain = 'Step-free access from the car park. Assistance dogs welcome.'
+      expect(getSafeAccessibilityNotes({ accessibility_notes: plain })).toBe(plain)
     })
   })
 


### PR DESCRIPTION
## What changed

`getSafeAccessibilityNotes` no longer withholds accessibility copy when the banned phrase appears inside a denial.

## Why

The source copy has now been corrected in the management app. Seven events claimed "step-free access throughout the ground floor with an accessible toilet"; they now carry the SSOT wording, which says plainly that we do not have one.

That correction would have been invisible on the site. The guard suppressed any notes matching `/accessible toilet/`, and the honest sentence contains that phrase:

> We do not currently have an accessible toilet.

So the page would have shown nothing at all, which is worse than the corrected text and defeats the purpose of fixing the data.

The guard now checks whether the phrase is denied or asserted, looking only at the words immediately preceding it. "We have an accessible toilet, but no baby changing facilities" still reads as an assertion and is still withheld.

## Testing done

- [x] 34 passing in `tests/event-seo-strategy.test.ts`, including five new cases: assertion withheld, denial kept, assertion-alongside-unrelated-denial withheld, empty/missing returns null, ordinary notes untouched.
- [x] Full suite 1339 passing.
- [x] `tsc` clean, lint clean.

## Complexity score

XS

## Breaking changes

None.

## Migration risk

None. Strictly more accurate information shown than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)