### PR TITLE
fix(events): stop the hero of an ended event inviting people to attend it

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -37,7 +37,7 @@ import { getEventBookingCopy } from '@/lib/event-booking-copy'
 import { getEventBookingHeroStatement } from '@/lib/event-booking-experience'
 import { getEventSeoStrategy, getCategoryPageUrl, isDiscontinuedFormatEvent, getDiscontinuedFormatReplacement, getSafeAccessibilityNotes, CANCELLED_INDEX_DAYS } from '@/lib/event-seo-strategy'
 import { getEventPresentation } from '@/lib/event-presentation'
-import { getEventMetaDescription, getDisplayableFaqs } from '@/lib/event-copy'
+import { getEventMetaDescription, getDisplayableFaqs, getEventHeroLead } from '@/lib/event-copy'
 import { getUpcomingEventsByCategory, isRetiredEvent } from '@/lib/api/events'
 import type { Event } from '@/lib/api'
 import RelatedEvents from '@/components/events/RelatedEvents'
@@ -401,14 +401,12 @@ export default async function EventPage({ params }: Props) {
     `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><rect fill="${event.category?.color || '#1a1a2e'}" width="1" height="1"/></svg>`
   ).toString('base64')}`
   const heroRoute = `/events/${encodeURIComponent(canonicalSegment || params.id)}`
-  const rawHeroDescription = event.shortDescription || event.brief || null
-  const eventSummary = rawHeroDescription
-    ? rawHeroDescription.length > 160
-      ? rawHeroDescription.substring(0, 157).trimEnd() + '…'
-      : rawHeroDescription
-    : undefined
+  // The lead is the largest text after the title, so it is the worst place for
+  // the wrong tense. An ended event used to fall straight back to its stored
+  // summary, which is sales copy: "Join us for Music Bingo on June 12th! Get
+  // ready for big tunes" sat directly under a banner saying it had ended.
   const heroDescription = bookingFormSuppressed
-    ? eventSummary
+    ? getEventHeroLead(event, getEventBookingHeroStatement(event))
     : getEventBookingHeroStatement(event)
   const heroTags = [
     ...(event.category?.name ? [{ label: event.category.name, variant: 'primary' as const }] : []),

--- a/lib/event-copy.ts
+++ b/lib/event-copy.ts
@@ -39,6 +39,49 @@ export function getDisplayableFaqs<T extends FaqLike>(faqs: T[], hasEnded: boole
   return faqs.filter((faq) => !BOOKING_QUESTION_PATTERN.test(faq.name || ''))
 }
 
+/**
+ * Whether a piece of stored copy reads as an invitation to attend.
+ *
+ * Event copy is written to sell tickets, so on a night that has passed it turns
+ * into "Join us for Music Bingo on June 12th! Get ready for big tunes" sitting
+ * under a banner that says the event has ended. Used to decide whether stored
+ * copy can be reused as-is on an ended page, or whether to fall back to a plain
+ * past-tense line.
+ */
+function readsAsInvitation(text: string): boolean {
+  return /\b(get ready|join us|book (your|now|online)|don'?t miss|grab your|secure your|coming up|see you (there|then)|this (friday|saturday|sunday|monday|tuesday|wednesday|thursday))\b/i.test(
+    text,
+  )
+}
+
+/**
+ * The lead paragraph in the page hero.
+ *
+ * This is the largest text on the page after the title, so it is the worst
+ * place for the wrong tense. An upcoming event gets its booking statement; an
+ * ended one keeps its stored summary only when that summary is not an
+ * invitation, and otherwise gets a plain past-tense line.
+ */
+export function getEventHeroLead(
+  event: Pick<
+    Event,
+    'name' | 'startDate' | 'event_status' | 'eventStatus' | 'category' | 'shortDescription' | 'brief' | 'bookings_enabled' | 'booking_cutoff_at'
+  >,
+  liveStatement: string
+): string | undefined {
+  const { hasEnded } = getEventPresentation(event)
+  const summary = event.shortDescription || event.brief || null
+
+  if (!hasEnded) return liveStatement
+
+  if (summary && !readsAsInvitation(summary)) {
+    return summary.length > 160 ? `${summary.substring(0, 157).trimEnd()}…` : summary
+  }
+
+  const date = eventDateLabel(event)
+  return `${event.name} took place at The Anchor${date ? ` on ${date}` : ''}.`
+}
+
 function eventDateLabel(event: Pick<Event, 'startDate'>): string {
   return (
     formatEventLocalDate(event.startDate, {
@@ -93,13 +136,7 @@ export function getEventSchemaDescription(
   const stored =
     event.longDescription || event.about || event.description || event.shortDescription
 
-  // Stored copy is kept on an upcoming event, and on an ended one only when it
-  // does not read as an invitation. "Get ready for a massive night" on a night
-  // eight weeks gone is the same defect as the meta description had.
-  const readsAsInvitation =
-    /\b(get ready|join us|book (your|now|online)|don'?t miss|grab your|secure your|coming up|this (friday|saturday|sunday|monday|tuesday|wednesday|thursday))\b/i
-
-  if (stored && !(hasEnded && readsAsInvitation.test(stored))) return stored
+  if (stored && !(hasEnded && readsAsInvitation(stored))) return stored
 
   if (hasEnded) {
     const date = eventDateLabel(event)

--- a/tests/event-copy.test.ts
+++ b/tests/event-copy.test.ts
@@ -10,6 +10,7 @@ import {
   getEventMetaDescription,
   getEventSchemaDescription,
   getDisplayableFaqs,
+  getEventHeroLead,
 } from '@/lib/event-copy'
 import type { Event } from '@/lib/api'
 
@@ -87,6 +88,47 @@ describe('getEventSchemaDescription', () => {
     expect(
       getEventSchemaDescription(makeEvent({ startDate: new Date(Date.now() - 5 * DAY).toISOString() })).length,
     ).toBeGreaterThan(0)
+  })
+})
+
+describe('getEventHeroLead', () => {
+  const LIVE = 'Reserve a table for Friday 14 August. No payment now, pay £5 on arrival.'
+
+  it('uses the booking statement while the event is upcoming', () => {
+    expect(getEventHeroLead(makeEvent(), LIVE)).toBe(LIVE)
+  })
+
+  it('never leaves an invitation in the hero of an ended event', () => {
+    // This was live on /events/music-bingo-2026-06-12: the largest text on the
+    // page said "Join us for Music Bingo on June 12th! Get ready for big
+    // tunes", directly under a banner saying the event had ended.
+    const lead = getEventHeroLead(
+      makeEvent({
+        startDate: new Date(Date.now() - 30 * DAY).toISOString(),
+        shortDescription:
+          'Join us for Music Bingo at The Anchor on June 12th! Get ready for big tunes, laughs, and a fun night out.',
+      }),
+      LIVE,
+    )
+    expect(lead).not.toMatch(/join us|get ready/i)
+    expect(lead).toContain('took place at The Anchor')
+  })
+
+  it('keeps a neutral stored summary on an ended event', () => {
+    const neutral = 'A music bingo night hosted by Nikki Manfadge, with two rounds and prizes.'
+    const lead = getEventHeroLead(
+      makeEvent({ startDate: new Date(Date.now() - 30 * DAY).toISOString(), shortDescription: neutral }),
+      LIVE,
+    )
+    expect(lead).toBe(neutral)
+  })
+
+  it('falls back to a past-tense line when there is no summary at all', () => {
+    const lead = getEventHeroLead(
+      makeEvent({ startDate: new Date(Date.now() - 30 * DAY).toISOString() }),
+      LIVE,
+    )
+    expect(lead).toContain('Music Bingo took place at The Anchor')
   })
 })
 


### PR DESCRIPTION
## What changed

The hero lead paragraph on an event page now resolves through `lib/event-copy.ts`, so it cannot be in the wrong tense.

## Why

Found by opening the live page rather than reading the markup. `/events/music-bingo-2026-06-12` showed the ended banner, the next date, past-tense facts ("Took place", "Entry was", "Started") and no booking button. Then immediately below, in the largest text on the page after the title:

> Join us for Music Bingo at The Anchor on June 12th! Get ready for big tunes, laughs, and a fun night out with friends and family.

#86 fixed the head description, the Open Graph card and the JSON-LD. It missed the one piece of copy an actual visitor reads first, because that path fell back to the stored `shortDescription`, which is sales copy.

An ended event now keeps its stored summary only when that summary is not an invitation, and otherwise gets a plain past-tense line. The invitation test is shared with `getEventSchemaDescription` rather than duplicated.

## Testing done

- [x] Four new cases in `tests/event-copy.test.ts`: upcoming keeps the booking statement, an ended invitation is replaced, a neutral stored summary is kept, and an absent summary falls back cleanly.
- [x] 1343 passing across 124 suites.
- [x] `tsc` clean, lint clean, production build compiles.

## Assumptions

- A neutral stored summary is worth keeping on an ended page. These pages exist to accumulate content, so replacing good descriptive copy with a generated sentence would work against that. Only copy that reads as an invitation is swapped.

## Complexity score

XS

## Breaking changes

None.

## Migration risk

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)