### PR TITLE
fix(events): strip nightclub-grade friction from the event booking form

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -480,7 +480,10 @@ export default async function EventPage({ params }: Props) {
       />
 
       {statusNotice ? (
-        <section className="pt-4 bg-canvas">
+        // Symmetric vertical padding. This was pt-4 with no bottom padding, which
+        // left the notice flush against the hero below it with nothing to separate
+        // the two. The scale matches the main content section further down.
+        <section className="bg-canvas py-4 sm:py-6">
           <Container>
             <div className="mx-auto max-w-6xl">
               <Alert variant={statusNotice.variant} title={statusNotice.title}>

--- a/components/CommunicationConsentFields.tsx
+++ b/components/CommunicationConsentFields.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  GUEST_COMPACT_CONSENT_NOTICE,
   GUEST_MARKETING_EMAIL_LABEL,
   GUEST_MARKETING_SMS_LABEL,
   GUEST_MARKETING_WHATSAPP_LABEL,
@@ -12,11 +13,35 @@ import {
 type CommunicationConsentFieldsProps = {
   value: CommunicationConsentState
   onChange: (next: CommunicationConsentState) => void
+  /**
+   * 'checkboxes' (default) asks for explicit consent per channel. Keep it on
+   * journeys where soft opt-in does not obviously apply, such as parking and
+   * private hire enquiries.
+   *
+   * 'compact' renders a single line of small print instead, for event bookings
+   * where PECR soft opt-in already permits inviting a past guest to the next
+   * similar night. See GUEST_COMPACT_CONSENT_NOTICE for the reasoning.
+   */
+  variant?: 'checkboxes' | 'compact'
 }
 
-export function CommunicationConsentFields({ value, onChange }: CommunicationConsentFieldsProps) {
+export function CommunicationConsentFields({
+  value,
+  onChange,
+  variant = 'checkboxes',
+}: CommunicationConsentFieldsProps) {
   const update = (key: keyof CommunicationConsentState, checked: boolean) => {
     onChange({ ...value, [key]: checked })
+  }
+
+  if (variant === 'compact') {
+    // No inputs, so no consent flags are set here. Reach is governed by the
+    // absence of marketing_sms_opted_out_at, not by a tick, which keeps the
+    // stored record honest: we never claim someone said yes when they were
+    // simply never asked.
+    return (
+      <p className="text-xs leading-relaxed text-ink-muted">{GUEST_COMPACT_CONSENT_NOTICE}</p>
+    )
   }
 
   return (

--- a/components/features/EventBooking/ManagementEventBookingForm.tsx
+++ b/components/features/EventBooking/ManagementEventBookingForm.tsx
@@ -10,7 +10,7 @@ import { trackEventBookingComplete, trackEventBookingFunnelStep, trackEventBooki
 import type { Event, EventTicketType } from '@/lib/api'
 import { getEventTicketTypes, hasMultipleTicketPrices } from '@/lib/api'
 import { isEventBookingClosed } from '@/lib/event-lifecycle'
-import { getEventBookingReassurance, getEventUnitPrice, formatEventBookingMoney } from '@/lib/event-booking-experience'
+import { getEventBookingReassurance, getEventUnitPrice, formatEventBookingMoney, isPrepaidEvent } from '@/lib/event-booking-experience'
 import {
   areSelectionNamesComplete,
   buildTicketSelections,
@@ -20,6 +20,7 @@ import {
   isSelectionOverCapacity,
 } from '@/lib/event-ticket-selection'
 import { PhoneLink } from '@/components/PhoneLink'
+import { cn } from '@/lib/utils'
 import { CONTACT } from '@/lib/constants'
 import { getBookingAttributionPayload, getMarketingConsentSignalPayload } from '@/lib/booking-attribution'
 import { PayPalEventPaymentSection, type EventPaymentConversionPayload } from './PayPalEventPaymentSection'
@@ -204,12 +205,19 @@ export function ManagementEventBookingForm({
   // prices AND is not communal (communal keeps its seated/standing chooser).
   const ticketTypes = getEventTicketTypes(event)
   const isMultiTypeEvent = !isCommunalEvent && hasMultipleTicketPrices(event)
-  // Paid events require a name for every ticket (booker is ticket 1).
+  // Prepaid events require a name for every ticket (booker is ticket 1), so the
+  // team knows who is coming against seats that are already paid for.
+  //
+  // This used to key off "is there a price", which caught every cash_only night
+  // too. That meant someone booking a £5 bingo for four had to know and type
+  // three friends' full names before the submit button would enable, on a phone,
+  // for a night they pay for at the door. Every upcoming event is free or
+  // cash_only, so that friction was firing on all of them and earning nothing.
   const eventUnitPrice = getEventUnitPrice(event)
   const isPaidEvent = typeof eventUnitPrice === 'number' && eventUnitPrice > 0
   // Single-type name collection is skipped entirely in the multi-type flow,
   // which collects a name per seat under each type instead.
-  const collectsAttendeeNames = !isMultiTypeEvent && isPaidEvent && seats > 1
+  const collectsAttendeeNames = !isMultiTypeEvent && isPrepaidEvent(event) && seats > 1
   const requiredAdditionalAttendeeCount = Math.max(0, seats - 1)
   // Multi-type derived state.
   const multiTypeTotalSeats = getTotalSeats(ticketQuantities)
@@ -252,8 +260,10 @@ export function ManagementEventBookingForm({
   }, [isCommunalEvent, seatedDisabled, seatingPreference, standingDisabled])
 
   // Keep the additional-attendee inputs in step with the seat count (tickets 2..N).
+  // Only prepaid events collect them, so everything else clears the array and the
+  // submit gate below never waits on names that are not being asked for.
   useEffect(() => {
-    if (!isPaidEvent) {
+    if (!collectsAttendeeNames) {
       setAdditionalAttendeeNames((prev) => (prev.length === 0 ? prev : []))
       return
     }
@@ -264,7 +274,7 @@ export function ManagementEventBookingForm({
       while (next.length < needed) next.push('')
       return next
     })
-  }, [isPaidEvent, seats])
+  }, [collectsAttendeeNames, seats])
 
   useEffect(() => {
     if (formViewedTracked.current) return
@@ -391,19 +401,22 @@ export function ManagementEventBookingForm({
         ? ticketSelections.flatMap((line) => line.attendee_names)
         : null
     } else {
-      // Booker is ticket 1; collect a name for every remaining ticket on paid events.
+      // Booker is ticket 1; collect a name for every remaining ticket, but only on
+      // prepaid events where the seats are paid for before the night.
       const additionalNamesForSubmit = Array.from(
         { length: Math.max(0, clampedSeats - 1) },
         (_, index) => (additionalAttendeeNames[index] ?? '').trim()
       )
 
-      if (isPaidEvent && additionalNamesForSubmit.some((name) => name.length === 0)) {
+      if (collectsAttendeeNames && additionalNamesForSubmit.some((name) => name.length === 0)) {
         setLoading(false)
         setError('Please enter a name for every ticket.')
         return
       }
 
-      attendeeNames = isPaidEvent
+      // Still send the booker's own name on any prepaid event, including a
+      // single-seat booking where no additional names were collected.
+      attendeeNames = isPrepaidEvent(event)
         ? [`${resolvedFirstName} ${resolvedLastName}`.trim(), ...additionalNamesForSubmit]
         : null
     }
@@ -805,29 +818,59 @@ export function ManagementEventBookingForm({
               ) : null}
             </fieldset>
           ) : (
-            <Input
-              label="Seats"
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              required
-              value={seatsDisplay}
-              onChange={(event) => {
-                const raw = event.target.value
-                if (raw !== '' && !/^\d+$/.test(raw)) return
-                setSeatsDisplay(raw)
-                if (raw === '') return
-                const parsed = Number.parseInt(raw, 10)
-                if (Number.isNaN(parsed)) return
-                setSeats(Math.min(Math.max(parsed, 1), 20))
-              }}
-              onBlur={() => {
-                const parsed = Number.parseInt(seatsDisplay, 10)
-                const clamped = (!Number.isFinite(parsed) || parsed < 1) ? 1 : Math.min(parsed, 20)
-                setSeats(clamped)
-                setSeatsDisplay(String(clamped))
-              }}
-            />
+            <div className="space-y-2">
+              {/* Quick picks first, so the common sizes are one tap and never open
+                  a keyboard. Average booking here is three to four seats, so 1 to 6
+                  covers nearly everything; the field below still takes any number
+                  up to 20 for the rare larger group. */}
+              <div className="flex flex-wrap gap-2" role="group" aria-label="Choose number of seats">
+                {[1, 2, 3, 4, 5, 6].map((count) => {
+                  const selected = seats === count && seatsDisplay === String(count)
+                  return (
+                    <button
+                      key={count}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => {
+                        setSeats(count)
+                        setSeatsDisplay(String(count))
+                      }}
+                      className={cn(
+                        'min-h-[44px] min-w-[44px] rounded-md border px-3 text-base font-semibold transition-colors',
+                        selected
+                          ? 'border-accent bg-accent text-white'
+                          : 'border-line bg-surface text-ink hover:border-accent'
+                      )}
+                    >
+                      {count}
+                    </button>
+                  )
+                })}
+              </div>
+              <Input
+                label="Seats"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                required
+                value={seatsDisplay}
+                onChange={(event) => {
+                  const raw = event.target.value
+                  if (raw !== '' && !/^\d+$/.test(raw)) return
+                  setSeatsDisplay(raw)
+                  if (raw === '') return
+                  const parsed = Number.parseInt(raw, 10)
+                  if (Number.isNaN(parsed)) return
+                  setSeats(Math.min(Math.max(parsed, 1), 20))
+                }}
+                onBlur={() => {
+                  const parsed = Number.parseInt(seatsDisplay, 10)
+                  const clamped = (!Number.isFinite(parsed) || parsed < 1) ? 1 : Math.min(parsed, 20)
+                  setSeats(clamped)
+                  setSeatsDisplay(String(clamped))
+                }}
+              />
+            </div>
           )}
 
           {isCommunalEvent ? (
@@ -898,10 +941,7 @@ export function ManagementEventBookingForm({
               <legend className="px-1 text-sm font-semibold text-ink">Who are the tickets for?</legend>
               <div className="space-y-1.5 px-1">
                 <p className="text-xs leading-relaxed text-ink-muted">
-                  Ticket 1 is you. Add the full name for each of the other {requiredAdditionalAttendeeCount} {requiredAdditionalAttendeeCount === 1 ? 'ticket' : 'tickets'}.
-                </p>
-                <p className="text-xs font-semibold leading-relaxed text-ink">
-                  Please use each guest’s real name — everyone will need photo ID matching their ticket on the night.
+                  Ticket 1 is you. Add a first name for each of the other {requiredAdditionalAttendeeCount} {requiredAdditionalAttendeeCount === 1 ? 'ticket' : 'tickets'}, so we know who to expect.
                 </p>
               </div>
               <div className="space-y-2.5">
@@ -928,8 +968,8 @@ export function ManagementEventBookingForm({
           {isMultiTypeEvent && multiTypeTotalSeats > 0 ? (
             <fieldset className="space-y-3 rounded-sm border border-line bg-surface-sunk p-3">
               <legend className="px-1 text-sm font-semibold text-ink">Who are the tickets for?</legend>
-              <p className="px-1 text-xs font-semibold leading-relaxed text-ink">
-                Please use each guest’s real name — everyone will need photo ID matching their ticket on the night.
+              <p className="px-1 text-xs leading-relaxed text-ink-muted">
+                Add a first name for each ticket, so we know who to expect.
               </p>
               <div className="space-y-4">
                 {multiTypeBreakdown.lines.map((line) => (
@@ -992,6 +1032,7 @@ export function ManagementEventBookingForm({
           <CommunicationConsentFields
             value={communicationConsent}
             onChange={setCommunicationConsent}
+            variant="compact"
           />
 
           {/* Honeypot, hidden from real users, filled by bots */}

--- a/lib/communication-consent.ts
+++ b/lib/communication-consent.ts
@@ -14,6 +14,20 @@ export const GUEST_MARKETING_SMS_LABEL =
 export const GUEST_WHATSAPP_SERVICE_LABEL = 'Send booking updates by WhatsApp.'
 export const GUEST_MARKETING_WHATSAPP_LABEL = 'Send me WhatsApp event and offer updates.'
 
+// Compact notice for the event booking form. Four tick boxes on a £5 bingo
+// booking cost more conversions than the explicit consent was worth, and the
+// venue does not need that consent to invite a past guest to its next event:
+// UK PECR soft opt-in covers marketing your own similar services to someone whose
+// details you took during a booking, provided they are given a simple way to
+// refuse. This notice is that simple way, and `marketing_sms_opted_out_at`
+// (set by the NOEVENTS keyword in the management app) is what honours it.
+//
+// Deliberately no WhatsApp here. WhatsApp business messaging needs explicit
+// opt-in under Meta's own platform rules, which soft opt-in does not satisfy, so
+// it is simply not offered at booking time rather than quietly assumed.
+export const GUEST_COMPACT_CONSENT_NOTICE =
+  'We will use your phone and email to manage this booking, and to text you about upcoming quiz nights, bingo and live music. Reply NOEVENTS to any message to stop event texts.'
+
 export type CommunicationConsentPayload = {
   service_contact_notice_shown: boolean
   marketing_email_opt_in: boolean

--- a/lib/event-booking-experience.ts
+++ b/lib/event-booking-experience.ts
@@ -104,6 +104,23 @@ function hasOnlineDiscountSignal(event: EventBookingPaymentSource): boolean {
   return event.payment_mode === 'prepaid' || /prepaid|pre-pay|online|payment_link/.test(text)
 }
 
+/**
+ * True only when money is taken before the night.
+ *
+ * Deliberately strict: it reads `payment_mode` and nothing else. The fuzzy
+ * signals above sniff the event name and category, which is fine for choosing
+ * reassurance copy but far too loose to gate booking friction. An event merely
+ * called "... Ticket Night" must not start demanding a name per seat.
+ *
+ * The live payment modes are `free`, `cash_only` and `prepaid`. Only the last of
+ * those takes payment up front, so only the last justifies collecting a name for
+ * every guest.
+ */
+export function isPrepaidEvent(event: EventBookingPaymentSource): boolean {
+  const mode = typeof event.payment_mode === 'string' ? event.payment_mode.trim().toLowerCase() : ''
+  return mode === 'prepaid'
+}
+
 export function getEventUnitPrice(event: EventBookingPaymentSource): number | null {
   // Multi-type events: ticket-type prices are already the final (post-discount)
   // charge, so the discount must not be re-applied — return the lowest directly.

--- a/tasks/event-ads-conversion-discovery-2026-08-08.md
+++ b/tasks/event-ads-conversion-discovery-2026-08-08.md
@@ -1,0 +1,230 @@
+# Event ads: why clicks are not becoming bookings
+
+Discovery, 8 August 2026. Evidence from the CheersAI database (`nbkjciurhvkfpcpatbnt`),
+the management database (`tfcasgxopxegwrabvwat`), the live site, and both codebases.
+
+---
+
+## 1. The funnel in real numbers
+
+Nine Meta event campaigns, 2 May to 8 August 2026.
+
+| Measure | Value |
+|---|---|
+| Spend | £318 |
+| Impressions | 77,112 |
+| Clicks | 733 |
+| Online event bookings recorded (all sources, all time) | 6 |
+| Event bookings attributed to paid social | 4 |
+| Conversions Meta itself recorded | 0 on every campaign |
+
+Actual bookings for the advertised events:
+
+| Event | Date | Bookings | Seats | Capacity |
+|---|---|---|---|---|
+| Cash Bingo | 29 Jul | 5 | 19 | not set |
+| Quiz Night | 22 Jul | 4 | 14 | not set |
+| Music Bingo | 17 Jul | 7 | 21 | 60 |
+| Cash Bingo | 1 Jul | 7 | 28 | 50 |
+
+So roughly £45 to £59 of ad spend per event, producing at best a handful of the
+4 to 7 bookings each event receives.
+
+**The plumbing is not the problem.** All nine ad short links resolve cleanly (307)
+to the correct event page carrying full UTMs. The landing page is good: clear
+headline, honest reassurance ("No payment now, pay £5 on arrival"), a visible
+"Reserve table" button, phone number, facts strip, FAQs.
+
+---
+
+## 2. Finding 1: the objective switch on 12 May broke the economics
+
+This is the single biggest lever.
+
+| Launched | Objective | Optimisation |
+|---|---|---|
+| 2 May | `OUTCOME_TRAFFIC` | `LINK_CLICKS` |
+| 12 May onward | `OUTCOME_SALES` | `OFFSITE_CONVERSIONS` |
+
+Like for like, same event type, same 5 mile radius around Stanwell Moor:
+
+| Campaign | Objective | Spend | Impressions | Clicks | CTR | CPC | CPM |
+|---|---|---|---|---|---|---|---|
+| Music Bingo, 2 May | traffic | £29.61 | 17,542 | 196 | 1.12% | £0.15 | £1.69 |
+| Music Bingo, 7 Jul | sales | £58.77 | 10,055 | 79 | 0.79% | £0.74 | £5.84 |
+
+Twice the money, 40 per cent fewer clicks. Across all campaigns CPM went from
+£1.58 to £1.69 (May) up to £5.77 to £7.66 (June onward), and CPC from £0.14 to
+£0.15 up to £0.69 to £1.09.
+
+**Why it happened.** `OFFSITE_CONVERSIONS` asks Meta to find people likely to
+complete a booking. Meta needs roughly 50 optimisation events per ad set per week
+to exit the learning phase. It has received **one** event booking through CAPI in
+three months. The optimiser is blind, so it pays a large premium for users it
+cannot actually identify.
+
+Average frequency is only 1.14 to 1.58, so this is **not** audience fatigue. The
+audience is not burnt out. The bidding is broken.
+
+---
+
+## 3. Finding 2: the conversion signal barely exists
+
+From 87 recorded conversion events:
+
+| Signal | Count |
+|---|---|
+| Sent to Meta via CAPI | 55 |
+| Skipped, no marketing consent | 32 (37%) |
+| Carrying `fbc` (the click ID that ties a booking back to an ad) | 5 |
+| **Event** bookings actually sent to Meta | **1** |
+
+Two separate leaks:
+
+1. **37 per cent of all conversions are dropped at the cookie banner.** No consent,
+   no CAPI event.
+2. **Only 5 of 87 have `fbc`.** Without it Meta cannot connect a booking to the ad
+   that caused it, even when the event is sent.
+
+The result is that the campaigns optimising for conversions have effectively never
+been shown a conversion.
+
+---
+
+## 4. Finding 3: the booking form is built for a festival, not a £5 bingo night
+
+`components/features/EventBooking/ManagementEventBookingForm.tsx:212`
+
+```ts
+const collectsAttendeeNames = !isMultiTypeEvent && isPaidEvent && seats > 1
+```
+
+Any paid event booked for two or more people requires **the full name of every
+guest**, and the submit button is hard disabled until all names are filled
+(`:1025`). The on-screen copy reads (`:904`):
+
+> Please use each guest's real name, everyone will need photo ID matching their
+> ticket on the night.
+
+Average booking size is 3 to 4 seats, so **essentially every booking hits this**.
+
+A person clicking a Facebook ad on a Friday evening for a £5 country music bingo
+night must know and type their three friends' full legal names, and then tell them
+all to bring photo ID. For a village pub social night this is disproportionate.
+It is the highest friction point in the entire funnel.
+
+---
+
+## 5. Finding 4: the page copy tells people not to book online
+
+The event body copy says:
+
+> Tickets are just £5. Book your seats by calling 01753 682707 or pop in if space
+> allows.
+
+That sits directly above the online booking form. It offers two easier alternatives
+to the thing the ad spend is trying to make happen, and "pop in if space allows"
+actively grants permission not to book at all.
+
+---
+
+## 6. Finding 5: budget is fragmented past the point of learning
+
+Each campaign runs **3 ad sets and 9 ads on about £45 total**. That is roughly £5
+per creative and a few hundred impressions each. Neither Meta nor a human can learn
+anything from that. Ads cannot be judged, and delivery cannot optimise.
+
+---
+
+## 7. Finding 6: the creative is generic where the page is specific
+
+Top headlines by clicks:
+
+- "Tonight Only: Book Now!"
+- "2 Rounds + Pizza!"
+- "Instant Fun Awaits!"
+- "Quiz Night Awaits!" (used twice)
+- "Quiz & Laughs!"
+
+None of them name Nikki Manfadge (a genuine draw), the £5 price, the prizes, the
+Dolly Parton and Johnny Cash rounds, or Stanwell Moor. The landing page is more
+specific and more persuasive than the ads that pay to reach it.
+
+---
+
+## 8. Honest opinion
+
+Three things are true at once, and the third is the uncomfortable one.
+
+**The ads are not the main problem.** The targeting is sensible, the links work,
+the tracking architecture is well built. The bidding objective is wrong and the
+creative is bland, but neither would matter much if the rest worked.
+
+**The website is not the main problem either.** The landing page is well designed
+and the reassurance copy is good. One form rule and one sentence of body copy are
+doing most of the damage.
+
+**The goal may be the wrong goal.** At 4 to 7 bookings per event against £45 to £59
+of spend, you are paying roughly £8 to £12 per booking for a £5 ticket, before any
+allowance for people who would have come anyway. Most people who see a pub bingo
+ad and decide to come will simply turn up. Online bookings may be a poor measure of
+whether the advertising works. Attendance on the night is the real number, and
+`event_check_ins` holds only 98 rows across all events, so it is not being used
+consistently enough to answer that question yet.
+
+Put plainly: you are spending real money asking Meta to optimise for an event it
+has seen once, and sending the people who do click into a form that asks for their
+friends' legal names.
+
+---
+
+## 9. Ideas to discuss, in priority order
+
+### A. Free, do first (measurement and bidding)
+
+1. **Switch event campaigns back to `OUTCOME_TRAFFIC` / `LINK_CLICKS`.** The
+   evidence is a clean like for like: same event, same radius, half the cost per
+   click. Revisit conversion optimisation only once volume justifies it.
+2. **Alternative: optimise for `LANDING_PAGE_VIEWS`** rather than link clicks, so
+   Meta filters out accidental taps without needing booking volume.
+3. **Fix `fbc` capture.** Only 5 of 87 conversions carry it. This is the difference
+   between attributed and invisible.
+4. **Revisit the consent gate.** 37 per cent of conversions are dropped there.
+   Worth checking the banner is not defaulting people into rejection.
+
+### B. Cheap, high impact (friction)
+
+5. **Drop the guest name requirement below a threshold.** Confirm the photo ID rule
+   is deliberate. If it is needed for genuinely ticketed events, gate it on those,
+   not on every paid event with two or more seats.
+6. **Remove "or pop in if space allows" from event body copy**, or move it well
+   below the form.
+7. **Cut the consent checkboxes** on the event form to the minimum legally needed.
+
+### C. Medium effort (creative and budget)
+
+8. **Consolidate budget.** Two or three ads per campaign, not nine. Give each
+   enough spend to learn.
+9. **Name the specific draw in the headline.** Nikki Manfadge, the £5 price, the
+   prize, the theme. Specificity beats "Instant Fun Awaits!".
+10. **Match the ad image to the landing page hero.** The hero is currently text
+    only, so the poster people tapped disappears on arrival.
+
+### D. Strategic (reframe)
+
+11. **Measure attendance, not online bookings.** Use `event_check_ins` consistently
+    so the real question ("did the ad fill the room?") can be answered.
+12. **Consider whether these events need paid ads at all**, versus organic reach,
+    the existing customer list, and in-pub promotion. £45 per event buys a lot of
+    SMS to people who have already been.
+
+---
+
+## 10. Open questions for the owner
+
+1. Is the photo ID requirement deliberate, or inherited from a ticketed event type?
+2. Do you know roughly how many people actually attend these nights, versus the
+   4 to 7 who book?
+3. Was the 12 May switch to conversion optimisation a deliberate decision?
+4. What would "working" look like: more bookings, more attendance, or lower cost
+   per head?

--- a/tasks/event-attendance-recovery-plan-2026-08-08.md
+++ b/tasks/event-attendance-recovery-plan-2026-08-08.md
@@ -1,0 +1,253 @@
+# Event attendance: what actually broke, and the plan
+
+8 August 2026. Follow-up to `event-ads-conversion-discovery-2026-08-08.md`.
+
+The ads were never the machine that filled the room. The SMS was, and it was
+deleted on 17 January 2026.
+
+---
+
+## 1. The finding
+
+| Period | Events | Avg bookings/event | Avg seats/event |
+|---|---|---|---|
+| Jun to Dec 2025 (SMS running) | 16 | 29.1 | 43.6 |
+| Jan to Aug 2026 (SMS off) | 37 | 4.4 | 13.8 |
+
+Summer to summer, which removes the Christmas seasonality objection:
+
+| Period (June to September only) | Avg seats/event |
+|---|---|
+| 2025, SMS running | **49.4** |
+| 2026, SMS off | **13.2** |
+
+Checked for artefacts: zero reminder-only (0 seat) booking records in either
+period, so this is not a change in how records were stored.
+
+### What this means for the room
+
+The owner reports current attendance of **20 to 25 people** against 13.8 seats
+booked, so walk-ins make up roughly 40 per cent of the room. Capacity on the
+advertised nights is 50 to 60.
+
+Applying the same walk-in ratio to 2025, when 43.6 to 49.4 seats were booked
+before the night, those events would have been at or near capacity.
+
+**SMS running: a full room. SMS off: about 40 per cent full.**
+
+### What was sending
+
+`booking_reminders` shows what ran until 31 December 2025:
+
+| Reminder type | Sends | Purpose |
+|---|---|---|
+| `no_seats_1_week` | 595 | Nudge people who had **not** booked |
+| `no_seats_day_before` | 542 | Nudge people who had **not** booked |
+| `no_seats_2_weeks` | 188 | Nudge people who had **not** booked |
+| `booked_1_day` / `booked_1_week` / `has_seats_*` | 135 | Remind people who **had** booked |
+| `booking_confirmation` | 77 | Confirmations |
+
+**1,325 of those sends were invitations to people who had not yet booked.** That
+is the engine that filled the room.
+
+### Why it stopped
+
+- Last send of any kind: **31 December 2025**
+- Commit **`113e8d2b`, 17 January 2026, "Remove event/table bookings and check-in"**
+  deleted `src/app/api/cron/reminders/route.ts`
+- `booking_reminders` is now referenced only in `database.generated.ts`. No
+  application code writes to it.
+- All four reminder templates are `is_active: false` in `message_templates`
+
+The replacement cron, `event-guest-engagement`, handles `event_reminder_1d`
+(people who **have** booked), post-event review requests, and cross-promotion.
+
+**The "remind people who booked" half survived the refactor. The "invite people
+who have not booked" half was deleted and never replaced.** That is the entire gap.
+
+### Scale of the wasted asset
+
+- **709 customers opted in to SMS**
+- 1,030 customers, all with mobile numbers
+- 444 distinct people have booked an event before
+- 789 on the event interest list
+
+For comparison, three months and £318 of Meta spend produced 733 clicks and 4
+attributed bookings.
+
+---
+
+## 2. SMS: what to rebuild and how it should change
+
+### 2.1 Rebuild the non-booker nudge (the priority)
+
+A cron that, for each upcoming event, texts opted-in customers who have **not**
+booked. Restore the timings that worked: **1 week before** and **day before**.
+Treat `no_seats_2_weeks` as optional, its volume was much lower.
+
+### 2.2 Fix the copy
+
+Current inactive template:
+
+> Hey {{first_name}}, {{event_name}} is on {{event_date}} at {{event_time}}. You
+> haven't booked seats yet. Want to join us? Reply now. – The Anchor
+
+Four problems:
+
+1. **"You haven't booked seats yet" is nagging.** It frames the message around
+   the recipient's failure rather than the invitation.
+2. **No price.** £5 and £3 are strengths. They remove risk and they are the single
+   most persuasive fact available.
+3. **No link.** "Reply now" forces a member of staff to process every reply by
+   hand. It caps the whole system at whatever a human can handle, and it stops
+   anyone booking at 11pm.
+4. **No reason to come.** No host name, no theme, no prize.
+
+Suggested shape:
+
+> Hi {{first_name}}, Country Music Bingo this Friday, 7pm, with Nikki. £5, pay on
+> the night. Grab a table: {{link}}. The Anchor. Text STOP to opt out.
+
+Every marketing send needs the short link (trackable through the existing
+`l.the-anchor.pub` redirect infrastructure) and a STOP instruction.
+
+### 2.3 Keep what already works
+
+`event-guest-engagement` already handles 1-day reminders to booked guests and
+post-event review requests. Leave it alone. The new job should only target people
+with no booking for that event.
+
+---
+
+## 3. Booking journey: cut it to three fields
+
+### Current state
+
+For any paid event with 2 or more seats, the form asks for:
+
+- Seats
+- First name
+- Last name
+- **The full name of every additional guest** (submit button disabled until all
+  are filled, `ManagementEventBookingForm.tsx:212` and `:1025`)
+- Mobile number
+- Email (optional)
+- Four separate marketing consent checkboxes
+
+Plus the line: "everyone will need photo ID matching their ticket on the night."
+
+The owner has confirmed the photo ID requirement is **not deliberate**. Guest
+names are wanted only when tickets are **paid in advance**, and a simple first
+name is enough in that case.
+
+### Target state
+
+| Field | Notes |
+|---|---|
+| **Seats** | Tap control (1, 2, 3, 4, 5, 6+), not a dropdown |
+| **Name** | One field, not first plus last |
+| **Mobile** | For the confirmation text |
+
+That is it. Everything else goes:
+
+- **Photo ID copy: remove entirely.** It was never intended. The brand voice in
+  `prompts.ts:16` says The Anchor is "a friendly local, not a nightclub", which is
+  exactly right.
+- **Guest names: prepaid events only**, and a first name is enough. Gate on
+  `payment_mode` being prepaid, not on `isPaidEvent && seats > 1`.
+- Email: optional, or drop it. You have their mobile.
+- Four consent checkboxes: replace with one line of small print (see section 4).
+
+Target: a booking in under 15 seconds on a phone, three taps and two short typed
+fields.
+
+### 3.1 Also fix
+
+Remove the walk-ins instruction that undercuts the form. In
+`OJ-AnchorManagementTools/src/lib/event-seo/prompts.ts`:
+
+- **Line 36** lists `"walk-ins welcome where space allows"` as a phrase to imitate
+- **Paragraph 5** briefs the model to cover `"price, booking, capacity, when to
+  arrive, walk-ins"`
+
+Together these produce "Book your seats by calling 01753 682707 or pop in if space
+allows", printed directly above the booking form. Drop walk-ins from paid events
+and brief paragraph 5 to point at the on-page form first, phone second.
+
+---
+
+## 4. Consent: the owner's position is sound, with one carve-out
+
+The decision is to assume consent for event marketing, with unsubscribe available.
+That is defensible, and it splits into three cases.
+
+**Service messages** (booking confirmation, reminder for an event they booked)
+need no marketing consent at all. These have never been the issue.
+
+**Marketing messages to past customers** (telling a past bingo attendee about the
+next bingo) are covered by the PECR soft opt-in, provided all three hold:
+
+1. You got their details in the course of a sale or negotiations for a sale. A
+   previous booking qualifies.
+2. You are marketing your **own similar** products or services. Another event
+   night qualifies. A different line of business would not.
+3. They were given a simple opt-out **at the point of collection** and in **every**
+   subsequent message.
+
+Point 3 is the one to build for: a clear line on the booking form, and STOP in
+every marketing SMS. Both are cheap.
+
+**The carve-out: this does not cover Meta.** Sending hashed email and phone to
+Meta through CAPI for ad targeting is not a service message and is not soft
+opt-in. That still needs real consent, so keep the cookie banner doing its job
+there. Currently 32 of 87 conversions are skipped for exactly this reason, which
+is correct behaviour, not a bug.
+
+This is a summary of the regime, not legal advice. If in doubt on point 2, take
+proper advice.
+
+---
+
+## 5. Defining "working"
+
+The owner does not currently have a target. Proposed definition, since attendance
+is the real goal:
+
+**Working means 40 or more people in the room on an event night, at under £2 of
+marketing cost per head.**
+
+Reference points:
+
+| Channel | Cost per event | Heads delivered |
+|---|---|---|
+| Meta ads today | £45 to £59 | 4 attributed bookings across 3 months |
+| SMS to 709 opted-in customers | roughly £15 to £25 | historically took seats from 13.8 to 49.4 |
+
+To measure it, `event_check_ins` needs to be used consistently. It holds only 98
+rows across all events, so attendance is currently guesswork rather than data.
+
+---
+
+## 6. Priority order
+
+| # | Action | Effort | Expected effect |
+|---|---|---|---|
+| 1 | Rebuild the non-booker SMS nudge (1 week + day before) | Medium | The 49.4 vs 13.2 seat gap |
+| 2 | Add link and price to SMS copy, add STOP | Small | Removes the manual reply bottleneck |
+| 3 | Cut the booking form to three fields, remove photo ID | Medium | 2 to 3x on conversion |
+| 4 | Remove walk-ins from the copy prompt | Tiny | Stops the page undercutting itself |
+| 5 | Switch Meta back to traffic optimisation | Tiny | About 5x on cost per click |
+| 6 | Start recording check-ins every event | Process | Makes "working" measurable |
+| 7 | Always-on campaign to an auto-updating page | Medium | New customers only |
+
+Items 1 and 2 are worth more than everything else combined.
+
+---
+
+## 7. Open question
+
+Was the reminder system removed deliberately, or lost by accident in the January
+refactor? Commit `113e8d2b` is titled "Remove event/table bookings and check-in",
+which reads like a planned removal of a wider feature. If the nudges were dropped
+as collateral, rebuilding is uncontroversial. If they were switched off on
+purpose, it is worth knowing why before turning them back on.

--- a/tasks/meta-ads-change-brief-2026-08-08.md
+++ b/tasks/meta-ads-change-brief-2026-08-08.md
@@ -1,0 +1,117 @@
+# Meta Ads change brief
+
+For the developer to action in Ads Manager or via the CheersAI campaign builder.
+Prepared 8 August 2026.
+
+---
+
+## The one change that matters
+
+**Switch event campaigns from conversion optimisation back to traffic
+optimisation.**
+
+| Setting | Change from | Change to |
+|---|---|---|
+| Campaign objective | `OUTCOME_SALES` | `OUTCOME_TRAFFIC` |
+| Ad set optimisation goal | `OFFSITE_CONVERSIONS` | `LINK_CLICKS` (or `LANDING_PAGE_VIEWS`) |
+
+Leave bid strategy on `LOWEST_COST_WITHOUT_CAP`. Leave targeting alone (18 to 65,
+5 mile radius on 51.4625, -0.5021). Leave the destination short links alone: they
+resolve correctly and carry full UTMs.
+
+### Why
+
+Conversion optimisation asks Meta to find people likely to complete a booking.
+Meta needs roughly 50 optimisation events per ad set per week to leave the
+learning phase. It has received **one** event booking through CAPI in three
+months, so the optimiser is bidding blind and paying a large premium for people
+it cannot identify.
+
+The switch happened on 12 May 2026. Like for like, same event type, same radius:
+
+| Music Bingo campaign | Objective | Spend | Clicks | CPC | CPM | CTR |
+|---|---|---|---|---|---|---|
+| Launched 2 May | traffic | £29.61 | 196 | £0.15 | £1.69 | 1.12% |
+| Launched 7 Jul | sales | £58.77 | 79 | £0.74 | £5.84 | 0.79% |
+
+Twice the money, 40 per cent fewer clicks. Average frequency across all campaigns
+is 1.14 to 1.58, so this is not audience fatigue. It is broken bidding.
+
+Revisit conversion optimisation only once booking volume can actually feed it.
+
+---
+
+## Secondary changes, in priority order
+
+### 1. Consolidate the ad sets
+
+Currently 3 ad sets per campaign (`Warm-up`, `Tomorrow Push`, `Last Chance`) on
+about £45 total. That is three separate learning phases per campaign, each
+starting from zero, on £15 each.
+
+Use **one ad set** and handle timing through creative rotation inside it. If a
+second ad set is wanted, make it a warm audience built from the customer list
+rather than another slice of the same cold pool.
+
+### 2. Cut the number of ads
+
+Currently 9 to 16 ads per campaign. At £45 total that is about £5 per creative and
+a few hundred impressions each. Nothing can learn, and no ad can be judged.
+
+Run **3 or 4 ads** at a time.
+
+### 3. Fix the headlines
+
+Every headline must contain at least one concrete fact: a host name, a price, a
+date, or a named prize or theme. Current examples and the problem with them:
+
+| Current headline | Problem |
+|---|---|
+| "Instant Fun Awaits!" | Says nothing |
+| "Quiz Night Awaits!" | Says nothing, and used twice |
+| "Quiz & Laughs!" | Says nothing |
+| "Tonight Only: Book Now!" | Urgency with no reason |
+
+**Nikki Manfadge appears in zero headlines.** She is a genuine local draw. The
+£5 and £3 prices are strengths that remove risk, not details to hide.
+
+The generator already has the rule "punchy, specific, no generic phrases"
+(`src/lib/campaigns/generate.ts:112`). It is not being enforced. Add a hard
+constraint requiring a name, price, date or named prize.
+
+---
+
+## What NOT to change
+
+- **The destination links.** All nine short links resolve cleanly (307) to the
+  correct event page with full UTMs. The plumbing is fine.
+- **The targeting.** 5 mile radius around Stanwell Moor is right.
+- **The cookie consent banner.** It currently blocks 32 of 87 conversions from
+  reaching Meta, and that is correct behaviour. Sending hashed contact data to
+  Meta needs real consent and is not covered by soft opt-in.
+
+---
+
+## Worth fixing separately
+
+Only **5 of 87** recorded conversions carry `fbc`, the click identifier that ties
+a booking back to the ad that caused it. Without it Meta cannot attribute a
+booking even when the event is sent. Worth investigating whether `fbclid` is
+being captured and persisted reliably on landing.
+
+---
+
+## How to tell it worked
+
+Watch **CPC and CPM**, not conversions, for the first two weeks.
+
+- Target CPC: back under £0.20 (currently £0.69 to £1.09)
+- Target CPM: back under £2.00 (currently £5.77 to £7.66)
+
+If CPC has not fallen materially within a week of the switch, something else is
+wrong and it is worth looking again.
+
+Longer term, judge these campaigns on **attendance**, not online bookings. Most
+people who see a pub bingo ad and decide to come will simply turn up. That means
+recording check-ins consistently: `event_check_ins` holds only 98 rows across all
+events, so attendance is currently guesswork.

--- a/tests/unit/ManagementEventBookingForm.test.tsx
+++ b/tests/unit/ManagementEventBookingForm.test.tsx
@@ -99,16 +99,52 @@ describe('ManagementEventBookingForm', () => {
     // The 'Planning to eat before the event' tickbox has been removed
     expect(screen.queryByRole('checkbox', { name: /Planning to eat/i })).not.toBeInTheDocument()
     expect(screen.queryByText('Not a food pre-order.')).not.toBeInTheDocument()
-    // Paid multi-ticket bookings collect a real name per ticket
-    expect(screen.getByText('Who are the tickets for?')).toBeInTheDocument()
-    expect(screen.getByText(/photo ID matching their ticket on the night/i)).toBeInTheDocument()
-    expect(screen.getByLabelText('Ticket 2 name')).toBeInTheDocument()
+    // Pay-on-the-night events must not ask for a name per ticket. This is a £3
+    // quiz paid at the door, so the booker's own details are all we need.
+    expect(screen.queryByText('Who are the tickets for?')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Ticket 2 name')).not.toBeInTheDocument()
+    // The photo ID warning belongs to prepaid ticketing and was never intended
+    // for a village pub quiz night. It must not appear anywhere.
+    expect(screen.queryByText(/photo ID/i)).not.toBeInTheDocument()
     expect(screen.getByText('No payment now. Reserve seats online and pay £3 per person on arrival.')).toBeInTheDocument()
     expect(screen.queryByText('18 seats currently available.')).not.toBeInTheDocument()
     expect(screen.queryByText('How many seats should we hold?')).not.toBeInTheDocument()
     expect(screen.queryByText('Want to eat before the event?')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Name')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument()
+  })
+
+  // Regression guard. Collecting a name per guest used to be gated on "does this
+  // event have a price", which caught every cash_only night. Booking a £5 bingo
+  // for four then meant typing three friends' full legal names before the submit
+  // button would enable. Every upcoming event is free or cash_only, so this fired
+  // on all of them. Only prepaid events, where seats are paid for up front, have
+  // any reason to ask.
+  it('keeps the submit button enabled on a cash_only event without any guest names', async () => {
+    render(
+      <ManagementEventBookingForm
+        event={{
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          name: 'Cash Bingo',
+          slug: 'cash-bingo',
+          startDate: '2026-09-02T19:00:00+01:00',
+          time: '19:00',
+          price_per_seat: 5,
+          payment_mode: 'cash_only'
+        }}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText('Seats'), { target: { value: '4' } })
+    fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Jane' } })
+    fireEvent.change(screen.getByLabelText('Last name'), { target: { value: 'Guest' } })
+    fireEvent.change(screen.getByLabelText('Mobile number'), { target: { value: '07700900000' } })
+
+    expect(screen.queryByLabelText('Ticket 2 name')).not.toBeInTheDocument()
+    expect(screen.queryByText(/photo ID/i)).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Reserve my seats' })).not.toBeDisabled()
+    )
   })
 
   it('displays an inline error message on POLICY_VIOLATION instead of redirecting', async () => {
@@ -183,7 +219,7 @@ describe('ManagementEventBookingForm', () => {
     expect(screen.queryByLabelText('First name')).not.toBeInTheDocument()
   })
 
-  it('submits per-ticket names and omits food fields', async () => {
+  it('submits per-ticket names on a prepaid event and omits food fields', async () => {
     ;(global as any).fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString()
 
@@ -247,6 +283,9 @@ describe('ManagementEventBookingForm', () => {
           startDate: '2026-05-08T20:00:00+01:00',
           time: '20:00',
           price_per_seat: 6,
+          // Per-ticket names are collected on prepaid events only. Without this
+          // the form treats it as pay-on-the-night and asks for the booker alone.
+          payment_mode: 'prepaid',
           category: {
             id: 'cat-bingo',
             name: 'Bingo',
@@ -374,8 +413,8 @@ describe('ManagementEventBookingForm', () => {
     await waitFor(() => expect(screen.getByRole('radio', { name: /Standing/i })).toBeChecked())
 
     fireEvent.change(screen.getByLabelText('Seats'), { target: { value: '3' } })
-    fireEvent.change(await screen.findByLabelText('Ticket 2 name'), { target: { value: 'Al Two' } })
-    fireEvent.change(screen.getByLabelText('Ticket 3 name'), { target: { value: 'Bo Three' } })
+    // No per-ticket names here: this is a pay-on-the-night event, so the booker's
+    // own details are the whole form.
     fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Jane' } })
     fireEvent.change(screen.getByLabelText('Last name'), { target: { value: 'Guest' } })
     fireEvent.change(screen.getByLabelText('Mobile number'), { target: { value: '07700900000' } })
@@ -389,7 +428,9 @@ describe('ManagementEventBookingForm', () => {
 
     expect(payload.seats).toBe(3)
     expect(payload.seating_preference).toBe('standing')
-    expect(payload.attendee_names).toEqual(['Jane Guest', 'Al Two', 'Bo Three'])
+    // Pay-on-the-night, so no per-guest names are collected and the field is
+    // omitted from the payload rather than sent empty.
+    expect(payload.attendee_names).toBeUndefined()
     expect(payload.event_price).toBe(10)
     expect(payload.event_value).toBe(30)
   })
@@ -458,9 +499,8 @@ describe('ManagementEventBookingForm', () => {
     )
 
     fireEvent.change(screen.getByLabelText('Seats'), { target: { value: '4' } })
-    fireEvent.change(await screen.findByLabelText('Ticket 2 name'), { target: { value: 'Al Two' } })
-    fireEvent.change(screen.getByLabelText('Ticket 3 name'), { target: { value: 'Bo Three' } })
-    fireEvent.change(screen.getByLabelText('Ticket 4 name'), { target: { value: 'Cy Four' } })
+    // No per-ticket names here: this is a pay-on-the-night event, so the booker's
+    // own details are the whole form.
     fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Jane' } })
     fireEvent.change(screen.getByLabelText('Last name'), { target: { value: 'Guest' } })
     fireEvent.change(screen.getByLabelText('Mobile number'), { target: { value: '07700900000' } })


### PR DESCRIPTION
## What changed

Booking a £5 bingo night for four people required typing three friends' **full legal names**, with the submit button disabled until every one was filled, under a line reading *"everyone will need photo ID matching their ticket on the night"*.

- Photo ID copy removed entirely (owner confirmed it was never intended)
- Guest names now gated on `payment_mode === 'prepaid'` via a new `isPrepaidEvent` helper, not on "does this event have a price"
- Four marketing consent tick boxes replaced by one line of small print on event bookings
- Seats gains tap targets for 1 to 6, so common sizes never open a keyboard
- Fixed the status notice on ended event pages: `pt-4` with no bottom padding left it flush against the hero

## Why

The gate was "does this event have a price", which caught every `cash_only` night. **All 14 upcoming events are free or cash_only and not one is prepaid**, so this friction fired on all of them and earned nothing.

On consent: UK PECR soft opt-in already permits inviting a past guest to the next similar night, provided they get a simple way to refuse. The notice plus the `NOEVENTS` keyword is that way. No consent flag is set from it, so the stored record never claims someone said yes when they were simply never asked. WhatsApp is dropped from this form rather than quietly assumed, because Meta's platform rules require explicit opt-in that soft opt-in does not satisfy.

Parking and private hire keep the tick boxes, hence the `variant` prop rather than a rewrite.

## Testing done

- [x] Manual testing: verified on the running site at 4 seats. Zero ticket-name inputs, no photo ID copy, zero consent tick boxes, submit button enabled. Seat chips set the value correctly. Ended-event notice now has symmetric 16px padding
- [x] Automated tests: **980 pass** (81 suites). Added a regression test that locks the fix in, and corrected a test that had been asserting the friction on a pay-on-arrival event
- [x] Typecheck clean, ESLint clean, production build succeeds, hero audit passes on 119 templates

## Complexity score

M

## Breaking changes

None. `CommunicationConsentFields` defaults to the existing four-checkbox behaviour; only the event booking form opts into `compact`.

## Migration risk

None. No schema changes in this repo.

## Related

Pairs with the-anchor-management-tools#99, which widens the SMS audience that fills these events. Neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)