### PR TITLE
fix: align SSOT with owner-confirmed facts from the GBP audit

### DIFF
--- a/SSOT.json
+++ b/SSOT.json
@@ -133,8 +133,7 @@
       "facebook": "https://www.facebook.com/theanchorpubsm/",
       "instagram": "https://www.instagram.com/theanchor.pub/",
       "whatpub": "https://whatpub.com/pubs/SRY/14044/anchor-stanwell-moor",
-      "twitter": "https://twitter.com/TheAnchor_Pub",
-      "linkedin": "https://linkedin.com/company/102814641"
+      "_no_twitter_or_linkedin": "Owner-confirmed 8 August 2026: The Anchor has no X/Twitter or LinkedIn account. Do not add them to sameAs, footers, blog posts or the Google Business Profile. Facebook and Instagram are the only social accounts."
     },
     "schema_org": {
       "types": [
@@ -228,7 +227,10 @@
       "Beer garden (under Heathrow flight path)",
       "Pool table",
       "Darts",
+      "Fruit machine",
       "Jukebox",
+      "Table service (food is brought to tables)",
+      "Space to dance",
       "Live sports on TV (terrestrial only: BBC/ITV/Channel 4)",
       "Luggage storage",
       "Private event space / function room",

--- a/content/blog/new-dining-room/index.md
+++ b/content/blog/new-dining-room/index.md
@@ -162,17 +162,13 @@ We acknowledge that the transformation journey might bring a bit of hustle and b
 
   
 
-Stay tuned for regular updates on our progress! We invite you to join us on this journey by following us on social media. For the latest news straight from The Anchor, connect with us on Facebook, Instagram, Twitter, and LinkedIn. Links to our profiles are conveniently listed below for your ease:
+Stay tuned for regular updates on our progress! We invite you to join us on this journey by following us on social media. For the latest news straight from The Anchor, connect with us on Facebook and Instagram. Links to our profiles are conveniently listed below for your ease:
 
   
 
 *   **Facebook:** [https://www.facebook.com/theanchorpubsm](https://www.facebook.com/theanchorpubsm)
     
 *   **Instagram:** [https://www.instagram.com/theanchor.pub/](https://www.instagram.com/theanchor.pub/)
-    
-*   **Twitter:** [https://twitter.com/TheAnchor\_Pub](https://twitter.com/TheAnchor_Pub)
-    
-*   **LinkedIn:** [https://www.linkedin.com/company/102814641](https://www.linkedin.com/company/102814641)  
     
 
 As we eagerly anticipate the completion of the new Dining Room, we extend a hearty invitation to our esteemed guests, old and new. Prepare to be charmed by the warmth of The Anchor, as we continue to serve you with the same love and cheer that has been our trademark for years. Here's to new beginnings, here's to The Anchor, your home away from home!

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -290,7 +290,11 @@ When the kitchen is closed for a date, food and Sunday-lunch slots return empty.
 
 > The canonical amenities list (with full wording) is `SSOT.json` `venue.amenities`. The summary below is for quick human reference; reconcile to the JSON if they ever differ.
 
-Free parking · Free WiFi (throughout pub and beer garden) · Beer garden (under Heathrow flight path) · Pool table · Darts · Jukebox · Live sport on terrestrial TV · Luggage storage · Private event space / function room · Dog friendly · Board games · Community notice board.
+Free parking · Free WiFi (throughout pub and beer garden) · Beer garden (under Heathrow flight path) · Pool table · Darts · Fruit machine · Jukebox · Table service · Space to dance · Live sport on terrestrial TV · Luggage storage · Private event space / function room · Dog friendly · Board games · Community notice board.
+
+**Table service:** food is brought to tables. Owner-confirmed 8 August 2026.
+
+**Fruit machine and dancing:** the pub has a fruit machine, and there is space for guests to dance. Owner-confirmed 8 August 2026. Both are recorded here because the matching Google Business Profile attributes ("Has arcade games", "Has dancing") are set to Yes and were previously flagged as unsupported.
 
 ### Things The Anchor does NOT have
 

--- a/tasks/gbp-change-list-2026-08-08.md
+++ b/tasks/gbp-change-list-2026-08-08.md
@@ -1,0 +1,175 @@
+# GBP change list for approval
+
+**Date:** 8 August 2026
+**Profile:** The Anchor, CID 17928230944823812473
+Companion to [gbp-review-2026-08-08.md](gbp-review-2026-08-08.md).
+
+Everything below is ready to apply. All URLs verified as returning 200 on 8 August 2026. All claims checked against `docs/SSOT.md`.
+
+---
+
+## Status as of 8 August 2026, end of session
+
+| Change | Status |
+|---|---|
+| Kitchen hours, all 7 days | **Live and verified** on the public panel |
+| Description amended | **Live** |
+| "Has table service" set to Yes | Pending Google review |
+| Service area cleared | Done by owner |
+| H. "Modern British restaurant" removed | Pending Google review |
+| D. Website UTM | Pending Google review |
+| F. 31 August special hours (16:00 to 22:00) | Pending Google review |
+| G. Repo cleanup, dead X/LinkedIn links | **Done**, SSOT valid, 34/34 drift-guard tests pass |
+| B. Review reply | **Blocked**, see below |
+| C. Q&A, 7 entries | Not started |
+| E. Posts, weekly | Not started |
+| A. Products, 7 entries | **Blocked on photos** |
+
+### B is blocked by a Google UI fault, not by a decision
+
+The merchant Reviews panel loads its list in a virtualised scroller that stops advancing after the third review, on both "Newest" and "Most relevant" sorts. The target review sits below that point and cannot be reached by scrolling, clicking or keyboard navigation.
+
+**Workaround for the owner:** open the public listing, find the review by jasmine claypool in the displayed top three, and use Edit on the existing owner reply. The replacement wording is in section B below. It takes under a minute from the customer-facing side, where the list renders normally.
+
+## Dropped, no longer applicable
+
+- **X/Twitter and LinkedIn.** The owner confirms these accounts do not exist. See section G for the cleanup this triggers in the repo.
+- **Special hours for 31 August.** The owner confirms no special hours. Normal Monday applies: bar 16:00 to 22:00, kitchen closed. See section F for the one thing still worth doing.
+
+---
+
+## A. Products, 7 entries
+
+**Path:** merchant panel, **Edit products**.
+
+Products are the workaround for the Pub category not exposing food attributes. This is the only place "vegan", "kids' menu" and "Sunday roast" can appear as words Google reads on the profile itself.
+
+**Prices: leave every price field blank.** `docs/SSOT.md` requires prices to come live from the management DB, and a price typed into GBP would go stale silently with nobody watching it. The link does the work instead.
+
+**Photos: each product needs one, and I do not have them.** Square or 4:3, 720px minimum. This is the one part of the list that needs you.
+
+| # | Product name | Link | Description |
+|---|---|---|---|
+| 1 | Sunday Roast | `/sunday-roast` | Traditional Sunday roast served 1pm to 6pm. Walk-ins welcome, no pre-order needed. Beef topside, pork leg, turkey with stuffing, pies, and a fully vegan Wellington. |
+| 2 | Vegan Wellington | `/sunday-roast` | Beetroot and butternut squash Wellington, fully vegan, served with vegan gravy as standard. Available every Sunday. |
+| 3 | Kids' Menu | `/food-menu` | Smaller portions for younger guests, including a kids' roast on Sundays. High chairs available. |
+| 4 | Christmas Lunch and Dinner | `/christmas-parties` | Sit-down Christmas lunch and dinner, 10 November to 20 December, for groups of 6 or more. One, two or three courses. |
+| 5 | Festive Buffets | `/christmas-parties` | Festive buffet catering for groups of 30 or more. |
+| 6 | Private Hire and Function Room | `/private-hire` | Function room for 10 to 150 guests. Birthdays, corporate events, celebrations and wakes. Free parking for every guest. |
+| 7 | Quiz Night | `/quiz-night` | Pub quiz with teams and prizes on the night. Free to enter, no need to book. |
+
+---
+
+## B. One review reply to correct
+
+**Review:** jasmine claypool, Local Guide, posted roughly November 2025. Currently one of the three reviews Google displays on the profile.
+
+**What it says:** Sunday dinner is "served until 5 p.m." and you "typically have to order on the Saturday night".
+
+**Why it matters:** both were retired at the 17 May 2026 walk-in launch. The review cannot be edited or removed, but the owner reply sits directly beneath it and Google, AI Overviews and Gemini all read both. Right now the reply thanks them without correcting the facts, so the profile is actively publishing an out-of-date booking policy.
+
+**Note:** Google replaces the reply rather than appending, so this is a full rewrite of the existing one.
+
+**Proposed replacement reply:**
+
+> Thank you so much, Jasmine. We're delighted you stumbled across us and enjoyed your Sunday dinner, and it means a lot to hear such kind words from visitors travelling so far from home.
+>
+> One update for anyone reading this now: our Sunday roast no longer needs pre-ordering. Walk-ins are welcome from 1pm to 6pm every Sunday, and there is no Saturday cut-off any more.
+
+**Also worth doing:** a scan of the other 281 reviews and replies for the same stale pre-order or Saturday cut-off language. I can do this if you want it.
+
+---
+
+## C. Q&A, 7 entries
+
+**Path:** the profile's "Questions and answers" section on Google Search, signed in as the owner.
+
+Google explicitly permits an owner to post a question and answer it themselves. Q&A answers are pulled into AI Overviews, which makes this one of the cheapest wins on the list.
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | Do I need to book for Sunday roast? | No. Walk-ins are welcome from 1pm to 6pm every Sunday. You can book a table online if you would rather be sure of one. |
+| 2 | Is the kitchen open on Mondays? | The bar is open from 4pm on Mondays but the kitchen is closed. Food is served Tuesday to Sunday. |
+| 3 | Is there parking? | Yes, 20 free spaces on site, no charge and no time limit while you are with us. The car park is floodlit with CCTV. |
+| 4 | How far is it from Heathrow? | Seven minutes from Terminal 5 and two minutes from M25 Junction 14. We are also outside the ULEZ zone. |
+| 5 | Are dogs allowed? | Yes, throughout the whole pub including the beer garden. We provide water bowls and dog biscuits. Dogs on leads, please. |
+| 6 | Do you have an accessible toilet? | No, we do not have an accessible toilet. The bar, dining area and car park are all step-free, and there is a ramp available on request for the beer garden. Please call us on 01753 682707 and we will help you plan your visit. |
+| 7 | Can you take large groups? | Yes. Private hire runs from 10 to 150 guests. Groups of 10 or more take a £10 per person deposit, which comes off the final bill. |
+
+Answering number 6 honestly is deliberate. It prevents a bad visit, and Google rewards profiles that answer real questions rather than dodging them.
+
+---
+
+## D. UTM tags on the two outbound links
+
+**Path:** Edit profile, Contact (website) and the booking link.
+
+Every visit from the profile currently lands in GA4 as direct or organic, so the profile gets no credit for the traffic or bookings it drives.
+
+| Field | Change to |
+|---|---|
+| Website | `https://www.the-anchor.pub/?utm_source=google&utm_medium=organic&utm_campaign=gbp` |
+| Booking link | `https://www.the-anchor.pub/book-table?utm_source=google&utm_medium=organic&utm_campaign=gbp_booking` |
+
+Trade-off, stated plainly: UTMs add no ranking value and are visible in the link preview on some surfaces. This is purely so you can prove what the profile is worth.
+
+---
+
+## E. Posts, move to weekly
+
+One post is live (Christmas, 1 August). Keep it until 20 December, then retire it.
+
+The events calendar is a ready-made content engine and needs no new writing. First three suggested:
+
+| When | Post | Link | Button |
+|---|---|---|---|
+| Now | Country music bingo, Friday 14 August | `/events/cowboys-queens-country-music-bingo-2026-08-14` | Learn more |
+| Now | Pub quiz, Wednesday 19 August | `/events/pub-quiz-quiz-night-2026-08-19` | Learn more |
+| Now | Sunday roast, walk-ins welcome 1pm to 6pm | `/sunday-roast` | Book |
+
+Then one per week off `/whats-on`.
+
+---
+
+## F. Bank holiday hours, confirm rather than change
+
+You have no special hours for Monday 31 August, so normal Monday applies: bar 16:00 to 22:00, kitchen closed.
+
+Google still shows a "Hours might differ" warning on bank holidays until the merchant confirms them. Confirming 31 August as **the same as usual** removes that warning without changing anything. Path: Edit profile, Hours, Special hours, confirm the public holiday.
+
+Same job needs doing for Christmas and New Year before the Christmas offer opens on 10 November, and those genuinely will differ.
+
+---
+
+## G. Repo cleanup triggered by the dead social accounts
+
+The owner confirms X/Twitter and LinkedIn do not exist. Two places still publish links to them:
+
+| File | Line | Issue |
+|---|---|---|
+| `SSOT.json` | 136 to 137 | `digital.social_media` lists `twitter` and `linkedin` URLs for accounts that do not exist |
+| `content/blog/new-dining-room/index.md` | 173, 175 | A published blog post gives readers both links |
+
+The live site schema `sameAs` is already clean; it lists only Facebook, Instagram, the Google Maps CID, Tripadvisor, OpenTable and the Food Standards Agency rating. So this is contained, but the blog post is customer-facing and currently sends readers to dead ends.
+
+**Proposed:** remove both entries from `SSOT.json`, and remove the two lines from the blog post.
+
+---
+
+## H. Category, one removal
+
+Remove **"Modern British restaurant"**. It contradicts the SSOT positioning of a traditional British village pub, and it invites comparison with a gastropub set The Anchor is not competing with. "British restaurant" and "Restaurant" already cover the food side.
+
+**Do not touch the primary category.** "Pub" is the strongest single ranking signal on the profile.
+
+---
+
+## I. Reviews, the standing job
+
+284 reviews at 4.6. The Retreat has 931 at 4.2, The Bells 667 at 4.4, The Rising Sun 334 at 4.3. Best rating in the area, second-lowest volume of the big three. Volume is a local pack factor.
+
+- Put the GBP short review link on receipts, table talkers and the post-booking confirmation email from the management app.
+- Ask on Sunday afternoons, when the review text shows satisfaction peaks.
+- Never incentivise. Google removes gated or paid reviews and it puts the profile at risk.
+
+Target: 400 reviews while holding 4.6.

--- a/tasks/gbp-review-2026-08-08.md
+++ b/tasks/gbp-review-2026-08-08.md
@@ -1,0 +1,282 @@
+# Google Business Profile review, The Anchor
+
+**Date:** 8 August 2026
+**Profile:** The Anchor, Horton Rd, Stanwell Moor, Staines TW19 6AQ
+**Place ID:** `ChIJDcbcERJxdkgReaFjdQ7fzfg` | **CID:** `17928230944823812473`
+**Method:** public Google Maps listing read live and compared against `docs/SSOT.md`, `SSOT.json`, and the live `/api/business/hours` feed. No dashboard access, so a few items are marked "verify in dashboard".
+
+---
+
+## Verdict
+
+The profile is in good shape and is clearly being managed. Rating is 4.6 from 284 reviews, the owner replies to reviews, photos are current (latest 4 days ago), the booking and menu links are wired up, and the name, address, phone, website, hours and coordinates all match the SSOT exactly. There is no NAP inconsistency to fix.
+
+The gains left are about **completeness and freshness**, not corrections. The three that move the needle are kitchen hours, a business description, and review volume.
+
+---
+
+## What is already correct (do not touch)
+
+| Item | Status |
+|---|---|
+| Business name "The Anchor" | Correct, matches SSOT, no keyword stuffing (stays policy-compliant) |
+| Address / post town | Correct (Royal Mail post town "Staines" is right for TW19 6AQ) |
+| Phone 01753 682707 | Correct |
+| Website `https://www.the-anchor.pub/` | Correct |
+| Booking link "Find a table" to `/book-table` | Correct and present |
+| Menu link | Present, and "Sunday Roast" / "Sunday Lunch" show as popular items |
+| Opening hours (Sun 12-10, Mon-Fri 4-10, Sat 12-10) | Match the live management API and site schema exactly |
+| Delivery attribute | Correctly marked "No delivery" (SSOT compliant) |
+| Wheelchair-accessible toilet | Correctly marked "No" (honest, SSOT compliant) |
+| Owner verification | Verified, listed as "The Anchor (owner)" |
+| Photo cadence | Latest upload 4 days ago |
+| Review responses | Owner is replying, personalised, good tone |
+| Site schema `sameAs` | Already links the GBP CID, which is the correct entity signal |
+
+---
+
+## Priority 1: Add kitchen hours under "More hours". DONE 8 Aug 2026
+
+Submitted and pending Google review. Path for next time: Edit profile, **Hours** tab, scroll past "Special hours", **Add more hours**, **+ Kitchen**.
+
+The kitchen runs on a completely different clock to the bar, which is why this mattered:
+
+| Day | Bar (on GBP) | Kitchen (actual) |
+|---|---|---|
+| Monday | 4pm - 10pm | **Closed all day** |
+| Tuesday | 4pm - 10pm | 4pm - 9pm |
+| Wednesday | 4pm - 10pm | 4pm - 9pm |
+| Thursday | 4pm - 10pm | 4pm - 9pm |
+| Friday | 4pm - 10pm | 4pm - 9pm |
+| Saturday | 12pm - 10pm | 12pm - 7pm |
+| Sunday | 12pm - 10pm | 1pm - 6pm (roast) |
+
+Right now Google believes food is available whenever the pub is open. That means the profile can surface for "food near me" or "Sunday roast near me" at times the kitchen cannot serve, and a Monday food visitor gets a wasted trip. Wasted trips are how 4.6 ratings become 4.4 ratings.
+
+**Action:** GBP dashboard, Edit profile, Hours, "Add more hours", choose **Kitchen**, and enter the grid above with Monday left blank.
+
+---
+
+## Priority 2: Amend the business description. DONE 8 Aug 2026
+
+Applied and pending Google review. The live description now ends:
+
+> ... Sunday roasts are served from 1pm to 6pm with walk-ins welcome, no pre-order needed. 5-star food hygiene rating. Serving the community since 1751.
+
+727 of 750 characters used. Background below.
+
+
+**Correction to the first version of this report.** A description does exist. It was not visible on the public Maps listing, which is why I first recorded it as missing. Dashboard access on 8 August confirmed it is live and it is good.
+
+Two changes to make:
+
+1. **Remove "Rated 4.6/5 on Google with a 5-star food hygiene rating."** Quoting your own Google rating back to Google inside a Google-owned field is a rejection risk, and the number goes stale by itself. Keep the food hygiene rating, drop the Google rating.
+2. **Add the Sunday roast walk-in policy.** It is the single highest-intent thing people search for here and the description does not mention that walk-ins are welcome.
+
+Everything else in the current description checks out against the SSOT, including "stone-baked pizzas" (`docs/SSOT.md` line 153, still live).
+
+**Suggested replacement for the final sentence:**
+
+> Sunday roasts are served from 1pm to 6pm with walk-ins welcome, no pre-order needed. 5-star food hygiene rating. Serving the community since 1751.
+
+**Full alternative draft (738 characters, all claims SSOT-verified), if you would rather replace the lot:**
+
+> The Anchor is a traditional British pub in Stanwell Moor, part of the community since 1751 and the closest village pub to Heathrow Airport, seven minutes from Terminal 5 and two minutes from M25 Junction 14. We serve famous Sunday roasts with walk-ins welcome from 1pm to 6pm, plus a full weekday menu, bottled ales, wine, spirits and cocktails. Our beer garden sits directly under the Heathrow approach path, with aircraft passing 500 to 800 feet overhead roughly every 90 seconds. There are 20 free parking spaces on site with no time limit, free WiFi throughout, and we are dog friendly in every part of the pub. We host quiz nights, cash bingo, music bingo, karaoke and live music, and we take private hire for 10 to 150 guests.
+
+Rules to keep it compliant: no links, no prices, no promotional offers, no all-caps.
+
+---
+
+## Priority 3: Close the review volume gap
+
+The Anchor has the best rating in its local set but not the most reviews. Google's local pack weighs review count as well as rating.
+
+| Pub | Rating | Reviews |
+|---|---|---|
+| **The Anchor** | **4.6** | **284** |
+| The Retreat | 4.2 | 931 |
+| The Bells | 4.4 | 667 |
+| The Rising Sun | 4.3 | 334 |
+| The Five Bells | 4.2 | 80 |
+
+The Anchor wins on quality and loses on volume. Getting from 284 towards 400 while holding 4.6 would make it the strongest profile in the area on both axes.
+
+**Actions:**
+- Use the GBP short review link on receipts, table talkers and the post-booking confirmation email from the management app.
+- Ask at the point of highest satisfaction, which the review text says is the Sunday roast, so ask on Sunday afternoons.
+- Never incentivise. Google removes gated or paid reviews and it puts the profile at risk.
+
+---
+
+## Priority 4: Fill the attribute gaps
+
+Attributes are how Google matches the profile to filtered and voice searches ("pub with high chairs near me", "vegan food near Heathrow"). Every true attribute left unticked is a query the profile cannot answer.
+
+**Correction to the first version of this report. There is nothing to add.** Every attribute group was opened and audited in the dashboard on 8 August. Every attribute Google offers under the **Pub** primary category is already set, and the ones set to No are correctly No (happy-hour drinks, happy-hour food, rooftop seating, gender-neutral toilets, drive-through, delivery, no-contact delivery, free multi-storey car park, cheques, cash-only).
+
+My original list of additions was drawn from Google's general restaurant attribute catalogue. The Pub category does not expose those fields. Verified group by group:
+
+| Group | Options Google actually offers under "Pub" | Verdict |
+|---|---|---|
+| Accessibility | 6 wheelchair and hearing options | All set |
+| Amenities | Gender-neutral toilets, toilet, Wi-Fi | All set. **No "high chairs", no "bar on site"** |
+| Children | "Good for kids" only | Set. **No "high chairs", no "kids' menu"** |
+| Crowd | LGBTQ+ friendly, transgender safe space | Both set. **No "family-friendly"** |
+| Dining options | Outside food allowed, seating, table service | All set. **No lunch, dinner, dessert or catering** |
+| Highlights | Bar games, karaoke, live music, live performances, quiz night, rooftop seating, watching sport | All set |
+| Offerings | Alcohol, arcade games, beer, cocktails, dancing, food, food at bar, free water refills, happy-hour drinks, happy-hour food, private dining room, spirits, wine | All set. **No vegetarian, vegan, coffee, kids' menu or dessert** |
+| Parking | On-site, free street, free lot, free multi-storey | All set. ("Plenty of parking" on the public listing is Google-inferred, not editable) |
+| Payments | Cash-only, cheques, credit, debit, NFC, VISA, Amex, Mastercard | All set |
+| Pets | Dogs allowed | Set |
+| Planning | Reservations required, accepts reservations | Both set |
+| Service options | Outdoor seating, delivery, no-contact delivery, takeaway, dine-in, on-site services, drive-through | All set |
+
+Also not owner-editable, despite appearing on the public listing: **Popular for** ("Solo dining") and **Atmosphere** ("Casual", "Cosy"). Google infers both from reviews and user behaviour.
+
+### Why the food attributes are missing, and what to do instead
+
+The attribute set is driven entirely by the **primary category**. "Pub" gives a pub-shaped list (bar games, karaoke, quiz night, arcade games, dancing). A **Restaurant** primary category would unlock the food attributes: vegetarian options, vegan options, kids' menu, dessert, coffee, high chairs, lunch, dinner, catering.
+
+**Do not swap the primary category for this.** "Pub" is almost certainly the right primary for the searches that matter ("pub near me", "pub near Heathrow", "pub Stanwell Moor"), and primary category is the single strongest ranking signal on the profile. Trading it for a handful of attributes would be a bad deal.
+
+It does mean the food signals have to come from elsewhere on the profile:
+
+- **Products** (currently empty). This is the main workaround. Sunday roast, vegan Wellington, kids' menu, Christmas menu, each with a photo and a link.
+- **The menu link**, already pointing at `/food-menu` and returning 200.
+- **Posts**, where "vegan Wellington" and "kids' menu" can appear as words Google reads.
+- **Reviews**, which is where "Popular for" and "Atmosphere" come from. Reviewers mentioning the roast, the vegan option and bringing kids is what moves those.
+
+**Three flagged attributes, all resolved by the owner on 8 August 2026:**
+
+| Attribute | Outcome |
+|---|---|
+| **Arcade games** | **Keep.** The pub has a fruit machine. Recorded in the SSOT so this is not re-flagged. |
+| **Dancing** | **Keep.** There is space for guests to dance. Recorded in the SSOT. |
+| **"No table service"** | **Changed to Yes and saved 8 August 2026, pending Google review.** Food is brought to tables. This was the one genuine error, and it matters: table service is one of the few food-related signals the Pub primary category exposes. |
+
+---
+
+## Priority 4b: Clear the service area
+
+**Found on 8 August via dashboard access. Not visible on the public listing.**
+
+The profile has a service area set: Ashford, Feltham, Longford, Egham, Englefield Green, Staines-upon-Thames, Colnbrook and Stanwell Moor. (Google itself removed Hounslow West at some point.)
+
+A service area tells Google you travel to the customer. The Anchor is a storefront: customers come to you, and the profile correctly carries the attribute "No delivery". So the service area does two unhelpful things at once. It does not widen the radius you rank in, which is set by your physical location and prominence, and it contradicts your own delivery attribute.
+
+**Action:** Edit profile, Location, Service area, remove all entries.
+
+If the goal was to rank in Ashford, Feltham and Staines, the levers that actually work are review volume from customers in those towns, locally relevant content on the site, and local citations. Not this field.
+
+---
+
+## Priority 4c: Add the two missing social profiles
+
+The profile lists Facebook and Instagram. The SSOT also has X/Twitter (`https://twitter.com/TheAnchor_Pub`) and LinkedIn (`https://linkedin.com/company/102814641`), and both are already in the site's schema `sameAs`. Adding them to GBP keeps the entity signals consistent across both.
+
+**Action:** Edit profile, Contact, Social profiles.
+
+---
+
+## Priority 5: Fix outdated information inside a top review
+
+One of the three reviews Google currently displays (jasmine claypool, 9 months ago) tells readers that Sunday dinner is "served until 5 p.m." and that you "typically have to order on the Saturday night". Both were retired at the 17 May 2026 walk-in launch. The current position is walk-ins welcome 1pm to 6pm with no pre-order and no Saturday cutoff.
+
+Reviews cannot be edited or removed for being out of date, but the owner reply can. Google displays the reply directly underneath, and AI answer engines read both.
+
+**Action:** edit the existing owner reply to append a correction, for example:
+
+> A quick update for anyone reading this now: our Sunday roast no longer needs pre-ordering. Walk-ins are welcome from 1pm to 6pm every Sunday.
+
+Worth a scan of the other 281 reviews and replies for the same stale pre-order and Saturday-cutoff language.
+
+---
+
+## Priority 6: Seed the Q&A section
+
+No questions are showing on the public profile. Google explicitly permits an owner to post a question and answer it themselves, and Q&A answers are pulled into AI Overviews.
+
+Suggested seeds, all SSOT-verified:
+
+1. Do I need to book for Sunday roast? *No. Walk-ins are welcome from 1pm to 6pm every Sunday. You can book a table online if you would prefer to be sure of a table.*
+2. Is the kitchen open on Mondays? *The bar is open from 4pm on Mondays but the kitchen is closed. Food is served Tuesday to Sunday.*
+3. Is there parking? *Yes, 20 free spaces on site, no charge and no time limit while you are with us. The car park is floodlit with CCTV.*
+4. How far is it from Heathrow? *Seven minutes from Terminal 5 and two minutes from M25 Junction 14. We are also outside the ULEZ zone.*
+5. Are dogs allowed? *Yes, throughout the whole pub including the beer garden. We provide water bowls and dog biscuits. Dogs on leads please.*
+6. Do you have an accessible toilet? *No, we do not have an accessible toilet. The bar, dining area and car park are all step-free, and there is a ramp available on request for the beer garden. Please call us on 01753 682707 and we will help plan your visit.*
+7. Can you take large groups? *Yes, private hire runs from 10 to 150 guests. Groups of 10 or more take a £10 per person deposit, which comes off the final bill.*
+
+Answering the accessible toilet question honestly is the right call. It prevents a bad visit and Google rewards profiles that answer real questions.
+
+---
+
+## Priority 7: Post weekly, not monthly
+
+There is one live post, published 1 August 2026 about Christmas. Posts do not directly move rankings, but they occupy the panel, they feed the "from the owner" slot, and they are one of the few places you control the words on your own listing.
+
+The events calendar is a ready-made content engine: quiz night, cash bingo, music bingo, karaoke, live music, curry club, games night, tasting nights. One post per week, each with a Book or Learn more button, is achievable without writing anything new.
+
+Keep the Christmas post running until 20 December 2026, then retire it.
+
+---
+
+## Priority 8: Tag the outbound links so you can measure GBP
+
+The website link currently points at `https://www.the-anchor.pub/` with no UTM parameters, so every visit from the profile lands in GA4 as direct or organic and the profile gets no credit.
+
+**Set:**
+- Website: `https://www.the-anchor.pub/?utm_source=google&utm_medium=organic&utm_campaign=gbp`
+- Booking: `https://www.the-anchor.pub/book-table?utm_source=google&utm_medium=organic&utm_campaign=gbp_booking`
+
+Note the trade-off: UTMs are visible in the link preview on some surfaces, and they add no ranking value. They are purely so you can prove what the profile is worth. Worth doing.
+
+---
+
+## Priority 9: Review the category list
+
+Current: **Pub** (primary), plus Beer garden, British restaurant, Events Venue, Family restaurant, Modern British restaurant, Restaurant.
+
+Primary category **Pub** is correct and should not change. It is the strongest single ranking signal on the profile.
+
+One to reconsider: **Modern British restaurant** contradicts the SSOT positioning of "traditional British village pub". It is unlikely to be doing harm, but it is off-brand and it competes with a set of gastropub-style venues The Anchor does not want to be compared with. Worth swapping for a category that reflects actual revenue, for example a function or event space category, given private hire runs 10 to 150 guests.
+
+---
+
+## Friday lunch: resolved, and it is a live booking bug
+
+**Owner confirmed 8 August 2026: food is served from 16:00 on Fridays.**
+
+So the Google Business Profile and the website are both correct, and the **management app is wrong**. Friday's `schedule_config` carries a bookable lunch service from 12:00 to 14:30, on a day the pub does not open until 16:00. Customers can currently reserve a Friday lunch table that cannot be honoured.
+
+This is not a GBP fix. It sits in `OJ-AnchorManagementTools` and has been raised as a separate task. Worth checking the other days for the same fault, since it looks like a copy of Saturday's config, and worth a validation guard so a slot cannot start before the day's opening time.
+
+---
+
+## Priority 10: Two dashboard tools sitting unused
+
+The merchant panel has **Edit products** and **Edit services** buttons, neither of which is populated.
+
+**Products** is the more useful of the two. Each product is a card with an image, a name, a price band and a link, and they surface in the profile's own carousel. Good candidates: Sunday Roast, Christmas lunch and dinner, private hire and function room, festive buffets, quiz night. It is the only place on the profile where you get to pair a photo with a price and a booking link.
+
+**Special hours** is also empty. The August bank holiday (Monday 31 August 2026) is the next one that matters, because Monday is normally a kitchen-closed day. Christmas and New Year need entering before the Christmas offer goes live on 10 November.
+
+---
+
+## Summary checklist
+
+- [x] Add Kitchen hours under "More hours" (Mon blank, Tue-Fri 16:00-21:00, Sat 12:00-19:00, Sun 13:00-18:00). Done 8 Aug 2026, pending Google review
+- [ ] Clear the service area
+- [x] Description amended. Done 8 Aug 2026, pending Google review. Dropped "Rated 4.6/5 on Google", added "Sunday roasts are served from 1pm to 6pm with walk-ins welcome, no pre-order needed." 727/750 characters
+- [x] Attributes audited 8 Aug 2026. Nothing to add: every attribute the Pub category offers is already set. Food attributes are not available under this primary category and the primary should not be changed to unlock them
+- [x] "Has table service" flipped to Yes. Done 8 Aug 2026, pending Google review
+- [x] "Arcade games" (fruit machine) and "Dancing" confirmed accurate by the owner and recorded in the SSOT
+- [ ] Add X/Twitter and LinkedIn to social profiles
+- [ ] Update the owner reply on the jasmine claypool review, and scan the rest for stale pre-order language
+- [ ] Start a review request routine, target 400 reviews at 4.6
+- [ ] Post and answer the seven Q&A entries
+- [ ] Move to a weekly post cadence driven by the events calendar
+- [ ] Populate Products (Sunday roast, Christmas, private hire, festive buffets, quiz night)
+- [ ] Enter special hours for the 31 August bank holiday, then Christmas and New Year
+- [ ] Add UTM parameters to the website and booking links
+- [ ] Review the "Modern British restaurant" category
+- [x] Friday resolved: food from 16:00 confirmed. GBP and website are correct; the phantom Friday lunch booking slot in the management app is raised as a separate task


### PR DESCRIPTION
## What changed

Removes two social media accounts that do not exist (X/Twitter and LinkedIn) from `SSOT.json` and from a published blog post that was linking to them. Adds three amenities the owner confirmed on 8 August: fruit machine, table service, and space to dance. Also adds the Google Business Profile audit and change list to `tasks/`.

## Why

The 8 August GBP audit compared the live Google Business Profile against the SSOT. Two problems came out of it.

The profile had no X or LinkedIn listed, and the owner confirmed neither account exists. But `SSOT.json` still carried both URLs and `content/blog/new-dining-room/index.md` was publishing them to readers as live links. The site's own schema `sameAs` was already clean, so this was contained, but the blog post was sending customers to dead ends.

Separately, three GBP attributes were flagged during the audit as having no SSOT backing: "Has arcade games", "Has dancing" and "Has table service". The owner confirmed all three are accurate (a fruit machine, floor space to dance, and food brought to tables). Recording them stops the next audit re-flagging them as unsupported claims, which is exactly the failure mode the SSOT exists to prevent.

## Testing done

- [x] Manual testing: confirmed nothing in the codebase reads `digital.social_media`, so removing those keys is inert. Grepped for remaining references to either account across `.ts`, `.tsx`, `.json` and `.md`; none remain.
- [x] Automated tests: `npx jest` 1344 passed / 1 skipped across 124 suites. SSOT drift guard 34/34. `npm run lint` clean including the hero and menu-page audits. `npx tsc --noEmit` clean.

## Complexity score

XS. Content and data only. No components, no logic, no types.

## Breaking changes

None.

## Migration risk

None. No schema, no database, no runtime code.

## Assumptions recorded

- The owner's confirmation that X and LinkedIn do not exist is treated as canonical over the previous SSOT entries.
- "Fruit machine" is recorded as the SSOT backing for Google's "Has arcade games" attribute, which is the closest option Google offers under the Pub category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)