### PR TITLE
fix(tracking): send the right Meta click ID, at the right click time

### DIFF
--- a/lib/booking-attribution.ts
+++ b/lib/booking-attribution.ts
@@ -6,6 +6,11 @@ const ATTRIBUTION_TTL_DAYS = 90
 const ATTRIBUTION_TTL_MS = ATTRIBUTION_TTL_DAYS * 24 * 60 * 60 * 1000
 const FBC_COOKIE_NAME = '_fbc'
 const FBP_COOKIE_NAME = '_fbp'
+// Meta's own `_fbc` cookie lives for 90 days, but the Pixel refreshes its expiry
+// on every page view, so a returning visitor can carry one indefinitely. Never
+// send a click older than that lifetime: it cannot attribute anything, and it
+// makes an organic booking look like an ad conversion.
+const FBC_MAX_AGE_MS = ATTRIBUTION_TTL_MS
 
 const PARAM_LIMITS: Record<AttributionParam, number> = {
   utm_source: 160,
@@ -19,6 +24,7 @@ const PARAM_LIMITS: Record<AttributionParam, number> = {
 }
 
 const ATTRIBUTION_PARAMS = Object.keys(PARAM_LIMITS) as AttributionParam[]
+const CLICK_ID_PARAMS: AttributionParam[] = ['fbclid', 'gclid']
 
 type AttributionParam =
   | 'utm_source'
@@ -43,6 +49,10 @@ interface StoredBookingAttribution {
   first: StoredAttributionEntry
   latest: StoredAttributionEntry
   expiresAt: string
+  // When `latest.params.fbclid` was first observed, which is the click time Meta
+  // expects inside `fbc`. Held separately because `latest.capturedAt` advances on
+  // every later campaign navigation while the click ID itself does not.
+  fbclidCapturedAt?: string
 }
 
 export interface BookingAttributionPayload {
@@ -58,6 +68,7 @@ export interface BookingAttributionPayload {
   short_code?: string
   attribution_captured_at?: string
   attribution_updated_at?: string
+  fbclid_captured_at?: string
   meta_consent_granted?: boolean
   fbp?: string
   fbc?: string
@@ -81,12 +92,15 @@ export function captureBookingAttributionFromLocation(now = new Date()): Booking
   // params, or when there's no prior record at all (so a purely organic first
   // session still stores a valid entry capturing its landing_path).
   const currentHasParams = Object.keys(current.params).length > 0
-  const latest = existing && !currentHasParams ? existing.latest : current
+  const latest = existing && !currentHasParams
+    ? existing.latest
+    : carryClickIdsForward(current, existing?.latest)
 
   const stored: StoredBookingAttribution = {
     first: existing?.first ?? current,
     latest,
     expiresAt: new Date(now.getTime() + ATTRIBUTION_TTL_MS).toISOString(),
+    fbclidCapturedAt: resolveFbclidCapturedAt(existing, latest, now),
   }
 
   writeStoredAttribution(stored)
@@ -108,11 +122,18 @@ export function getMarketingConsentSignalPayload(fbclid?: string | null): Bookin
     return { meta_consent_granted: false }
   }
 
-  const resolvedFbclid = fbclid ?? getBookingAttributionPayload().fbclid ?? currentFbclid()
+  const attribution = getBookingAttributionPayload()
+  const resolvedFbclid = fbclid ?? attribution.fbclid ?? currentFbclid()
+  // Only trust the stored click time when it belongs to the click ID we are about
+  // to send. A caller passing a different fbclid is reading it live off the URL.
+  const fbclidCapturedAt = resolvedFbclid === attribution.fbclid
+    ? attribution.fbclid_captured_at
+    : undefined
+
   return removeUndefined({
     meta_consent_granted: true,
     fbp: sanitizeSignal(readCookieValue(FBP_COOKIE_NAME), 500),
-    fbc: sanitizeSignal(readCookieValue(FBC_COOKIE_NAME) ?? buildFbcFromFbclid(resolvedFbclid), 500),
+    fbc: sanitizeSignal(resolveFbc(resolvedFbclid, fbclidCapturedAt), 500),
     client_user_agent: sanitizeSignal(window.navigator?.userAgent, 500),
   })
 }
@@ -152,6 +173,45 @@ function readAttributionFromUrl(urlValue: string, now: Date): StoredAttributionE
   }
 }
 
+/**
+ * Click IDs must survive a later campaign click that carries only UTMs. Arriving
+ * via a second short link (an SMS, an organic post) used to wipe the Meta click ID
+ * the ad brought in, leaving the booking unattributable. Meta's own `_fbc` cookie
+ * behaves this way too: it persists until a *new* click ID replaces it.
+ */
+function carryClickIdsForward(
+  current: StoredAttributionEntry,
+  previous: StoredAttributionEntry | undefined,
+): StoredAttributionEntry {
+  if (!previous) return current
+
+  const params: AttributionParams = { ...current.params }
+  let carried = false
+  for (const key of CLICK_ID_PARAMS) {
+    if (params[key] || !previous.params[key]) continue
+    params[key] = previous.params[key]
+    carried = true
+  }
+
+  return carried ? { ...current, params } : current
+}
+
+/**
+ * The click time Meta wants inside `fbc` is when the fbclid was seen, not when the
+ * booking was submitted. Only restamp when the click ID actually changes.
+ */
+function resolveFbclidCapturedAt(
+  existing: StoredBookingAttribution | null,
+  latest: StoredAttributionEntry,
+  now: Date,
+): string | undefined {
+  if (!latest.params.fbclid) return undefined
+  if (existing?.latest.params.fbclid !== latest.params.fbclid) return now.toISOString()
+  // Unchanged click ID. Records written before this field existed fall back to the
+  // entry's own capture time, which is the closest thing they hold to a click time.
+  return existing.fbclidCapturedAt ?? existing.latest.capturedAt
+}
+
 function sanitizeParam(key: AttributionParam, value: string | null): string | undefined {
   const trimmed = value?.trim()
   if (!trimmed) return undefined
@@ -182,6 +242,7 @@ function parseStoredAttribution(value: string | null): StoredBookingAttribution 
       first: parsed.first,
       latest: parsed.latest,
       expiresAt: parsed.expiresAt,
+      fbclidCapturedAt: typeof parsed.fbclidCapturedAt === 'string' ? parsed.fbclidCapturedAt : undefined,
     }
   } catch {
     return null
@@ -247,10 +308,47 @@ function currentFbclid() {
   }
 }
 
-function buildFbcFromFbclid(fbclid: string | null | undefined) {
-  const value = sanitizeSignal(fbclid, 500)
-  if (!value) return undefined
-  return `fb.1.${Date.now()}.${value}`
+/**
+ * Resolve the `fb.<subdomainIndex>.<clickTimeMs>.<fbclid>` value Meta expects.
+ *
+ * The Pixel writes `_fbc` with the true click time, so it wins whenever it holds
+ * the same click ID we captured. It must NOT win when it holds a different one:
+ * that cookie is a leftover from an earlier visit, and the click we captured this
+ * time is the one that brought the booking in. The Pixel only writes `_fbc` when
+ * it loads on a URL still carrying `fbclid`, which the consent banner routinely
+ * prevents, so the reconstructed value is the normal path rather than the edge case.
+ */
+function resolveFbc(fbclid: string | null | undefined, fbclidCapturedAt: string | undefined) {
+  const captured = sanitizeSignal(fbclid, 500)
+  const cookie = parseFbcCookie(readCookieValue(FBC_COOKIE_NAME))
+
+  if (captured) {
+    if (cookie?.fbclid === captured) return cookie.value
+    // Subdomain index 1 matches where the Pixel sets `_fbc` for this site: the
+    // registrable domain the-anchor.pub, one level below the public suffix.
+    return `fb.1.${resolveClickTimeMs(fbclidCapturedAt)}.${captured}`
+  }
+
+  if (cookie && Date.now() - cookie.createdAt <= FBC_MAX_AGE_MS) return cookie.value
+  return undefined
+}
+
+function parseFbcCookie(value: string | null) {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  const match = trimmed.match(/^fb\.\d+\.(\d+)\.(.+)$/)
+  if (!match) return null
+
+  const createdAt = Number(match[1])
+  if (!Number.isFinite(createdAt) || createdAt <= 0) return null
+
+  return { value: trimmed, createdAt, fbclid: match[2] }
+}
+
+function resolveClickTimeMs(fbclidCapturedAt: string | undefined) {
+  const parsed = fbclidCapturedAt ? Date.parse(fbclidCapturedAt) : Number.NaN
+  return Number.isFinite(parsed) ? parsed : Date.now()
 }
 
 function sanitizeSignal(value: string | null | undefined, max: number) {
@@ -273,6 +371,7 @@ function storedToPayload(stored: StoredBookingAttribution): BookingAttributionPa
     short_code: latest.short_code,
     attribution_captured_at: stored.first.capturedAt,
     attribution_updated_at: stored.latest.capturedAt,
+    fbclid_captured_at: latest.fbclid ? stored.fbclidCapturedAt ?? stored.latest.capturedAt : undefined,
   })
 }
 

--- a/tasks/meta-ads-change-brief-2026-08-08.md
+++ b/tasks/meta-ads-change-brief-2026-08-08.md
@@ -92,12 +92,44 @@ constraint requiring a name, price, date or named prize.
 
 ---
 
-## Worth fixing separately
+## The `fbc` gap: investigated 9 August 2026, not a bug
 
-Only **5 of 87** recorded conversions carry `fbc`, the click identifier that ties
-a booking back to the ad that caused it. Without it Meta cannot attribute a
-booking even when the event is sent. Worth investigating whether `fbclid` is
-being captured and persisted reliably on landing.
+The original note here asked whether `fbclid` was being captured and persisted
+reliably. It is. The low `fbc` count is a conversion problem, not a tracking one.
+
+Checked against `booking_conversion_events` (91 rows, 7 July to 8 August), the
+management short-link database, and a live probe of the ad short links:
+
+- **Only 4 of 91 conversions ever carried an `fbclid`**, because barely any paid
+  click becomes an online booking. Every paid click that did convert had its
+  `fbclid` captured: 4 out of 4.
+- July and August produced roughly **1,209 human paid-social link clicks** (2,670
+  total less 1,461 bots) against those 4 bookings. August alone: 592 paid clicks,
+  23 bookings, zero carrying an `fbclid`.
+- The short links pass `fbclid` through cleanly in a single 307 hop, verified live.
+- Of the 4 `fbclid` bookings, 3 had no marketing consent, so `fbc` was correctly
+  withheld. That is the banner working, and it stays.
+- Of the 5 bookings that did carry `fbc`, only **one** is a real ad attribution.
+  The other four carried the same `_fbc` cookie dated 13 January 2026, read six
+  months later on organic Facebook bookings. Far outside any Meta attribution
+  window, so it attributed nothing.
+
+**Read the real figure as 1 in 91, not 5 in 87.** It reinforces the main change
+above: there is nowhere near enough booking volume to feed conversion optimisation,
+and judging these campaigns on online bookings will keep understating them.
+
+Three genuine defects were found alongside this and fixed in `lib/booking-attribution.ts`:
+
+1. A stale `_fbc` cookie beat a freshly captured `fbclid`. The captured click now
+   wins when the two disagree, and a cookie older than Meta's own 90 day `_fbc`
+   lifetime is dropped rather than sent.
+2. `fbc` was stamped with the booking time instead of the click time. The click
+   time is now stored when the `fbclid` is first seen and used verbatim.
+3. `fbclid` was read only from the most recent campaign URL, so arriving via a
+   second link carrying only UTMs wiped it. Click IDs now carry forward.
+
+None of these touch consent gating. None will move the headline number much: they
+improve the quality of the few ad-attributed bookings that exist.
 
 ---
 

--- a/tests/unit/booking-attribution.test.ts
+++ b/tests/unit/booking-attribution.test.ts
@@ -83,6 +83,22 @@ describe('booking attribution persistence', () => {
     })
   })
 
+  it('carries the Meta click ID forward when a later campaign URL has none', () => {
+    window.history.pushState({}, '', '/events/quiz-night?utm_source=facebook&fbclid=fb-from-ad')
+    captureBookingAttributionFromLocation(FIRST_SEEN)
+
+    // A second short link (SMS, organic post) with UTMs but no fbclid used to wipe
+    // the click ID the ad brought in, leaving the booking unattributable.
+    window.history.pushState({}, '', '/book-table?utm_source=sms&utm_campaign=sunday-lunch')
+    const latestPayload = captureBookingAttributionFromLocation(LATER_SEEN)
+
+    expect(latestPayload).toMatchObject({
+      utm_source: 'sms',
+      utm_campaign: 'sunday-lunch',
+      fbclid: 'fb-from-ad',
+    })
+  })
+
   it('returns stored attribution after visitors navigate away from campaign URLs', () => {
     window.history.pushState({}, '', '/events/quiz-night?utm_campaign=quiz-night&short_code=ma-quiz')
     captureBookingAttributionFromLocation(FIRST_SEEN)
@@ -112,5 +128,78 @@ describe('booking attribution persistence', () => {
       fbp: 'fb.1.1710000000.browser-123',
       fbc: expect.stringContaining('fb-consented'),
     })
+  })
+})
+
+describe('Meta fbc resolution', () => {
+  beforeEach(() => {
+    clearBookingAttributionForTest()
+    window.localStorage.clear()
+    document.cookie = 'anchor-cookie-consent=; path=/; max-age=0'
+    document.cookie = '_fbc=; path=/; max-age=0'
+    setConsentStatus({ marketing: true })
+  })
+
+  afterEach(() => {
+    clearBookingAttributionForTest()
+    window.localStorage.clear()
+    document.cookie = 'anchor-cookie-consent=; path=/; max-age=0'
+    document.cookie = '_fbc=; path=/; max-age=0'
+  })
+
+  it('stamps fbc with the click time, not the booking time', () => {
+    window.history.pushState({}, '', '/events/quiz-night?fbclid=fb-clicked-earlier')
+    captureBookingAttributionFromLocation(FIRST_SEEN)
+
+    window.history.pushState({}, '', '/book-table')
+
+    expect(getMarketingConsentSignalPayload().fbc).toBe(`fb.1.${FIRST_SEEN.getTime()}.fb-clicked-earlier`)
+  })
+
+  it('prefers a freshly captured click over a stale _fbc cookie holding a different one', () => {
+    const staleClickMs = Date.now() - 180 * DAY_MS
+    document.cookie = `_fbc=fb.1.${staleClickMs}.fb-january-click; path=/`
+    window.history.pushState({}, '', '/events/quiz-night?fbclid=fb-todays-click')
+
+    const fbc = getMarketingConsentSignalPayload().fbc
+
+    expect(fbc).toContain('fb-todays-click')
+    expect(fbc).not.toContain('fb-january-click')
+  })
+
+  it('keeps the pixel-written cookie when it holds the same click, so the real click time survives', () => {
+    const clickMs = Date.now() - 2 * DAY_MS
+    document.cookie = `_fbc=fb.1.${clickMs}.fb-same-click; path=/`
+    window.history.pushState({}, '', '/events/quiz-night?fbclid=fb-same-click')
+
+    expect(getMarketingConsentSignalPayload().fbc).toBe(`fb.1.${clickMs}.fb-same-click`)
+  })
+
+  it('uses an in-window _fbc cookie when this visit captured no click ID', () => {
+    const clickMs = Date.now() - 10 * DAY_MS
+    document.cookie = `_fbc=fb.1.${clickMs}.fb-recent-click; path=/`
+    window.history.pushState({}, '', '/book-table')
+
+    expect(getMarketingConsentSignalPayload().fbc).toBe(`fb.1.${clickMs}.fb-recent-click`)
+  })
+
+  it('drops an _fbc cookie older than Metas own 90 day cookie lifetime', () => {
+    // The pixel refreshes _fbc expiry on every page view, so a returning visitor can
+    // carry a click ID for months. Sending it makes an organic booking look like an
+    // ad conversion, and it is far outside any Meta attribution window.
+    document.cookie = `_fbc=fb.1.${Date.now() - 120 * DAY_MS}.fb-ancient-click; path=/`
+    window.history.pushState({}, '', '/book-table')
+
+    const payload = getMarketingConsentSignalPayload()
+
+    expect(payload.meta_consent_granted).toBe(true)
+    expect(payload.fbc).toBeUndefined()
+  })
+
+  it('ignores a malformed _fbc cookie', () => {
+    document.cookie = '_fbc=not-a-valid-fbc-value; path=/'
+    window.history.pushState({}, '', '/book-table')
+
+    expect(getMarketingConsentSignalPayload().fbc).toBeUndefined()
   })
 })


### PR DESCRIPTION
## What changed

Investigating why only 5 of 87 booking conversions carried `fbc` turned up three real defects in client-side attribution capture. All three are fixed in `lib/booking-attribution.ts`, with tests. The brief at `tasks/meta-ads-change-brief-2026-08-08.md` is corrected: the headline number is not caused by these defects.

1. A stale `_fbc` cookie beat a freshly captured `fbclid`. The Pixel refreshes the cookie's expiry on every page view, so a returning visitor carries one indefinitely: four July bookings were sent a click ID dated 13 January. The captured click now wins when the two disagree, and a cookie older than Meta's own 90 day `_fbc` lifetime is dropped rather than sent.
2. `fbc` was stamped with `Date.now()` at form submission instead of the click time Meta expects. The click time is now recorded when the `fbclid` is first seen, carried across later navigations, and used verbatim.
3. `fbclid` was read only from the most recent campaign URL, so arriving via a second link carrying only UTMs (an SMS, an organic post) wiped the click ID the ad brought in. Click IDs now carry forward, matching how Meta's own `_fbc` cookie behaves.

## Why

The brief flagged that only 5 of 87 recorded conversions carried `fbc`, and asked whether `fbclid` was being captured reliably. It is. Checked against `booking_conversion_events` (91 rows, 7 Jul to 8 Aug), the management short-link database, and a live probe of the ad short links:

- Only **4 of 91** conversions ever carried an `fbclid`, because barely any paid click becomes an online booking. Every paid click that did convert had its `fbclid` captured: 4 of 4.
- July and August produced roughly **1,209 human paid-social link clicks** against those 4 bookings. August alone: 592 paid clicks, 23 bookings, zero `fbclid`.
- Short links pass `fbclid` through in a single 307 hop, verified live.
- 3 of the 4 `fbclid` bookings had no marketing consent, so `fbc` was correctly withheld. The consent banner is working and is deliberately untouched here.
- Of the 5 rows carrying `fbc`, only **one** is a real ad attribution. The other four carried the same January `_fbc` cookie, which is defect 1 above.

So the real figure is 1 in 91, not 5 in 87, and the constraint is booking volume rather than plumbing.

## Testing done

- [x] Manual testing: live probe of two ad short links confirming `fbclid` survives the 307 hop into the event page; live query of `booking_conversion_events` and `short_link_clicks` to establish the numbers above
- [x] Automated tests: 6 new tests covering each fix (click-time stamping, stale cookie losing to a fresh click, matching cookie winning, in-window cookie fallback, over-age cookie dropped, malformed cookie ignored). Full suite green: 124 suites, 1,351 tests. Lint, typecheck and production build all clean.

## Complexity score

S. Two files of meaningful change, no schema changes, no API contract change. Server-side attribution allowlists pick keys explicitly, so the new client-side `fbclid_captured_at` needs no downstream change.

## Breaking changes

None. Stored attribution records written before this change are read back without `fbclidCapturedAt` and fall back to the entry's own capture time.

## Migration risk

None. No database or environment changes. Consent gating is untouched.