### PR TITLE
fix(seo): self-canonicalise blog pagination and repair broken tag links

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,21 +7,35 @@ import { getTwitterMetadata } from '@/lib/twitter-metadata'
 import { PageTitle } from '@/components/ui/typography/PageTitle'
 import { InteriorHero } from '@/components/hero'
 import { getBlogHeroUrl, BLOG_FALLBACK_IMAGE } from '@/lib/blog-image'
-export const metadata: Metadata = {
-  title: 'Blog | Heathrow Travel Tips, Pub Events & Local Guides',
-  description: 'Read The Anchor blog for Heathrow Terminal 5 travel tips, pub events, food and drink guides, and community stories from Stanwell Moor and Staines.',
-  openGraph: {
-    title: 'The Anchor Blog - News, Events & Guides',
-    description: 'Heathrow travel tips, pub events, food and drink guides and local stories from The Anchor near Heathrow Terminal 5.',
-    images: [BLOG_FALLBACK_IMAGE],
-  },
-  twitter: getTwitterMetadata({
-    title: 'The Anchor Blog - News, Events & Guides',
-    description: 'Heathrow travel tips, pub events, food and drink guides and local stories from The Anchor near Terminal 5.',
-    images: [BLOG_FALLBACK_IMAGE]
-  }),
-  alternates: {
-    canonical: '/blog'
+// Each paginated page must canonicalise to itself. Pointing page 2+ at /blog
+// tells Google those pages are duplicates of page one, which hides every older
+// post from discovery. See Google's pagination guidance.
+export function generateMetadata({
+  searchParams,
+}: {
+  searchParams: { page?: string }
+}): Metadata {
+  const currentPage = Number(searchParams.page) || 1
+  const isFirstPage = currentPage <= 1
+  const canonical = isFirstPage ? '/blog' : `/blog?page=${currentPage}`
+  const titleSuffix = isFirstPage ? '' : ` - Page ${currentPage}`
+
+  return {
+    title: `Blog${titleSuffix} | Heathrow Travel Tips, Pub Events & Local Guides`,
+    description: 'Read The Anchor blog for Heathrow Terminal 5 travel tips, pub events, food and drink guides, and community stories from Stanwell Moor and Staines.',
+    openGraph: {
+      title: `The Anchor Blog - News, Events & Guides${titleSuffix}`,
+      description: 'Heathrow travel tips, pub events, food and drink guides and local stories from The Anchor near Heathrow Terminal 5.',
+      images: [BLOG_FALLBACK_IMAGE],
+    },
+    twitter: getTwitterMetadata({
+      title: `The Anchor Blog - News, Events & Guides${titleSuffix}`,
+      description: 'Heathrow travel tips, pub events, food and drink guides and local stories from The Anchor near Terminal 5.',
+      images: [BLOG_FALLBACK_IMAGE]
+    }),
+    alternates: {
+      canonical
+    }
   }
 }
 

--- a/content/blog/cheap-heathrow-parking-alternatives/index.md
+++ b/content/blog/cheap-heathrow-parking-alternatives/index.md
@@ -17,7 +17,6 @@ tags:
   - parking
   - heathrow
   - guides
-  - savings
 hero: "hero.jpg"
 images: []
 ---

--- a/content/blog/christening-party-ideas-venues/index.md
+++ b/content/blog/christening-party-ideas-venues/index.md
@@ -13,7 +13,6 @@ keywords:
   - naming ceremony venue
 tags:
   - private-hire
-  - christenings
   - guides
 featured: false
 hero: "hero.jpg"

--- a/content/blog/christmas-party-food-ideas/index.md
+++ b/content/blog/christmas-party-food-ideas/index.md
@@ -17,7 +17,7 @@ keywords:
   - christmas buffet
 tags:
   - seasonal
-  - food
+  - food-and-drink
 featured: false
 noindex: false
 hero: "hero.jpg"

--- a/content/blog/gender-reveal-party-ideas-venues/index.md
+++ b/content/blog/gender-reveal-party-ideas-venues/index.md
@@ -12,7 +12,6 @@ keywords:
   - gender reveal party planning
 tags:
   - private-hire
-  - gender-reveal
   - guides
 featured: false
 hero: "hero.jpg"

--- a/content/blog/heathrow-plane-spotting-locations/index.md
+++ b/content/blog/heathrow-plane-spotting-locations/index.md
@@ -10,10 +10,8 @@ keywords:
   - where to watch planes land at heathrow
   - heathrow aviation viewing
 tags:
-  - things-to-do
   - guides
   - heathrow
-  - plane-spotting
 featured: true
 hero: "hero.jpg"
 images: []

--- a/content/blog/how-to-plan-christening-reception/index.md
+++ b/content/blog/how-to-plan-christening-reception/index.md
@@ -11,7 +11,6 @@ keywords:
   - christening reception venue
 tags:
   - private-hire
-  - christenings
   - guides
 featured: false
 hero: "hero.jpg"

--- a/content/blog/leaving-party-ideas/index.md
+++ b/content/blog/leaving-party-ideas/index.md
@@ -12,7 +12,6 @@ keywords:
   - leaving party venue
 tags:
   - private-hire
-  - work-events
   - guides
 featured: false
 hero: "hero.jpg"

--- a/content/blog/live-music-pubs-near-heathrow/index.md
+++ b/content/blog/live-music-pubs-near-heathrow/index.md
@@ -11,8 +11,7 @@ keywords:
   - live bands heathrow
   - live music staines
 tags:
-  - entertainment
-  - live-music
+  - events
   - guides
 featured: false
 images: []

--- a/content/blog/pub-vs-hotel-celebration-venue/index.md
+++ b/content/blog/pub-vs-hotel-celebration-venue/index.md
@@ -12,7 +12,6 @@ keywords:
   - celebration venue near heathrow
 tags:
   - private-hire
-  - comparison
   - guides
 featured: false
 hero: "hero.jpg"

--- a/content/blog/retirement-party-ideas-venues/index.md
+++ b/content/blog/retirement-party-ideas-venues/index.md
@@ -11,7 +11,6 @@ keywords:
   - retirement celebration venue
 tags:
   - private-hire
-  - work-events
   - guides
 featured: false
 hero: "hero.jpg"

--- a/content/blog/wake-venue-near-heathrow/index.md
+++ b/content/blog/wake-venue-near-heathrow/index.md
@@ -15,7 +15,6 @@ keywords:
   - funeral tea near heathrow
 tags:
   - private-hire
-  - wakes
   - guides
 featured: false
 hero: "hero.jpg"


### PR DESCRIPTION
## What changed

Two genuine indexing defects surfaced by the 9 August GSC coverage export.

**Blog pagination canonicals.** `app/blog/page.tsx` hardcoded `canonical: '/blog'` as static metadata, so `/blog?page=2` onwards claimed to be page one. Converted to `generateMetadata` so each page self-canonicalises and carries a distinct title.

**Blog tag hygiene.** 18 of 31 tags in post frontmatter no longer resolved: 15 redirected to a consolidated tag, 3 pointed at landing pages. All were linked from the tag cloud and `/blog/tags`, so every crawl hit redirects. Normalised across 11 posts, leaving 13 tags that all return 200.

## Why

`/blog?page=2` was in GSC's "Alternative page with proper canonical" bucket and pages 1 and 3 to 7 were in "Crawled - currently not indexed". Canonicalising pagination to page one is a Google-documented anti-pattern that hides everything past the first 12 posts.

The tag redirects were pure crawl waste: 156 tag URLs across three GSC buckets, self-inflicted by internal links pointing at stale slugs.

## Assumptions

- Where a tag redirected to one already on the post (`christenings`, `wakes`, `work-events`, `gender-reveal` all point at `private-hire`), the redundant tag was dropped rather than duplicated.
- `live-music` redirects to the `/live-music` landing page rather than a tag, so that post now carries `events`.
- `content/blog/README.md` and `TEMPLATE.md` contain placeholder tags (`tag1`, `tag2`) but are not posts, so they were left alone.

## Testing done

- [x] Manual testing: canonicals confirmed on `/blog`, `/blog?page=2`, `/blog?page=5` against a running dev server. All 13 tag links from `/blog` and `/blog/tags` verified as live 200s.
- [x] Automated tests: 124 suites, 1351 tests pass. Lint clean, typecheck clean, production build succeeds.

Note: 4 suites fail under a bare `npx jest` run, but all 4 live in the stale worktree at `.claude/worktrees/serene-goodall-2b4711` and are unrelated to this change.

## Complexity score

S

## Breaking changes

None.

## Migration risk

None. No schema or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)