### PR TITLE
chore: stop jest scanning git worktrees for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,11 @@ const customJestConfig = {
     '**/__tests__/**/*.test.[jt]s?(x)',
     '**/?(*.)+(spec|test).[jt]s?(x)'
   ],
+  // Git worktrees live under .claude/worktrees/ and contain full checkouts of this
+  // repo. Without this, a bare `npx jest` also collects their tests, so stale or
+  // in-progress branches produce phantom failures that mask real regressions.
+  // next/jest appends these to its own defaults (/node_modules/ and <rootDir>/.next/).
+  testPathIgnorePatterns: ['/\\.claude/worktrees/'],
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
     'components/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
## What changed

Added `testPathIgnorePatterns: ['/\\.claude/worktrees/']` to `jest.config.js`, so a bare `npx jest` no longer walks into git worktrees under `.claude/worktrees/` and collects their test files.

The pattern goes in `customJestConfig` rather than the exported wrapper, because `next/jest` appends custom `testPathIgnorePatterns` onto its own defaults. The resolved config keeps all three: `/node_modules/`, `/.next/`, and the new worktree pattern.

## Why

`.claude/worktrees/` holds full checkouts of this repo. Jest was collecting their tests alongside the real suite, so any stale or in-progress branch sitting in a worktree produced phantom suite failures against the main checkout.

At the time this was found, four suites were "failing" purely from a worktree checkout:

- `lib/__tests__/sunday-roast.test.ts`
- `lib/__tests__/large-group-deposit.test.ts`
- `tests/ssot-drift-guard.test.ts`
- `tests/unit/ManagementTableBookingForm.test.tsx`

None of them reflected a defect in this branch. The practical risk is the reverse of noise: once a run is expected to show red, a genuine regression stops standing out.

## Testing done

- [x] Manual testing: `npx jest --showConfig` confirms the resolved `testPathIgnorePatterns` is `["/node_modules/", "/.next/", "/\\.claude/worktrees/"]`, so the `next/jest` defaults survive.
- [x] Manual testing: `npx jest --listTests` drops from 128 to 124 collected test files, with 0 files remaining under `.claude/worktrees/`.
- [x] Automated tests: bare `npx jest` reports 124 suites passed, 1351 tests passed, 1 skipped, 0 failed. Existing tests only, no new tests required for a config change.

## Complexity score

XS. Single file, five added lines, no schema or runtime impact.

## Breaking changes

None. Test collection only, no application code touched.

## Migration risk

None. The change is inert unless a worktree exists under `.claude/worktrees/`.

## Assumptions recorded

- The pattern is deliberately left unanchored (`/\.claude/worktrees/` rather than `<rootDir>/...`) so nested worktrees at any depth are excluded, not just those directly under the repo root.
- No project intentionally keeps tests inside `.claude/worktrees/`. Nothing in the repo suggests otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
