### PR TITLE
fix(seo): record drag cabaret as a retired format

### DIFF
--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -415,6 +415,7 @@ Discontinued unless reintroduced in event listings. Do not promote Nikki hosted/
 ### Retired entertainment formats
 
 - **Open mic is discontinued.** Do not list, promote, or link to open mic nights. The retired `/open-mic` route redirects to `/live-music`.
+- **Drag cabaret is discontinued.** Do not list, promote, or link to drag cabaret nights, and do not target drag cabaret or drag show keywords. **Music Bingo is the only drag night.** (Owner-confirmed, 9 Aug 2026.) The retired `/whats-on/drag-shows` route redirects to `/whats-on`, and past "Drag Cabaret & Karaoke" event pages stay live but out of search. Music Bingo copy may still refer to its drag host.
 
 ## 11. Private Hire
 

--- a/lib/event-seo-strategy.ts
+++ b/lib/event-seo-strategy.ts
@@ -26,6 +26,16 @@ export const CANCELLED_INDEX_DAYS = 7
  * docs/SSOT.md §"Nikki's Games Night": "Do not promote Nikki hosted/games
  * nights as a recurring format. Nikki currently hosts Music Bingo only."
  *
+ * docs/SSOT.md §"Retired entertainment formats": drag cabaret has stopped, and
+ * Music Bingo is now the only drag night. The three past "Drag Cabaret &
+ * Karaoke" events already fall out of the index because they sit under the
+ * "Nikki's Games Night" category, but that is incidental: the token below is
+ * what actually encodes the policy, so a new drag cabaret event filed under a
+ * karaoke category cannot quietly start ranking.
+ *
+ * Deliberately 'drag cabaret', not 'drag'. Music Bingo copy refers to its drag
+ * host and must stay indexable.
+ *
  * Open mic is the other retired format, handled separately by isRetiredEvent()
  * because it has a genuine replacement page and 301s to /live-music. A games
  * night has no equivalent, so the page stays live for anyone with the link and
@@ -45,6 +55,13 @@ const DISCONTINUED_FORMATS: ReadonlyArray<{
     replacementLabel: 'See Music Bingo dates',
     // SSOT: "Nikki currently hosts Music Bingo only."
     replacementCopy: 'This night is no longer running. Nikki hosts Music Bingo now.',
+  },
+  {
+    token: 'drag cabaret',
+    replacement: '/music-bingo',
+    replacementLabel: 'See Music Bingo dates',
+    // SSOT: "Music Bingo is the only drag night."
+    replacementCopy: 'This night is no longer running. Music Bingo is our drag night now.',
   },
 ]
 

--- a/tests/event-seo-strategy.test.ts
+++ b/tests/event-seo-strategy.test.ts
@@ -175,6 +175,43 @@ describe('getEventSeoStrategy', () => {
       expect(getDiscontinuedFormatReplacement({ name: 'Music Bingo' })).toBeNull()
     })
 
+    // docs/SSOT.md §"Retired entertainment formats": drag cabaret is
+    // discontinued and Music Bingo is the only drag night (owner-confirmed,
+    // 9 Aug 2026). The live records happen to sit under the "Nikki's Games
+    // Night" category, so this proves the name alone is enough.
+    it('noindexes a drag cabaret night on its name alone', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(400),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: 'Drag Cabaret & Karaoke',
+        slug: 'drag-cabaret-karaoke-may--2025',
+        category: { id: 'c1', slug: 'karaoke-night', name: 'Karaoke Night', color: '#000' },
+      })
+      expect(result.index).toBe(false)
+    })
+
+    it('points a drag cabaret night at Music Bingo', () => {
+      const replacement = getDiscontinuedFormatReplacement({ name: 'Drag Cabaret & Karaoke' })
+      expect(replacement?.href).toBe('/music-bingo')
+      expect(replacement?.copy).toContain('Music Bingo')
+    })
+
+    // 'drag cabaret', not 'drag'. Music Bingo copy refers to its drag host and
+    // must stay indexable, so the narrower token is load-bearing.
+    it('keeps a music bingo night indexable when its copy mentions a drag host', () => {
+      const result = getEventSeoStrategy({
+        startDate: isoDaysAgo(400),
+        event_status: 'scheduled',
+        eventStatus: 'scheduled',
+        name: "Nikki's Karaoke Night",
+        slug: 'nikkis-karaoke-night-2025-08-22',
+        description: 'Hosted by drag performer Nikki Manfadge.',
+      })
+      expect(result.index).toBe(true)
+      expect(getDiscontinuedFormatReplacement({ name: "Nikki's Karaoke Night" })).toBeNull()
+    })
+
     it('keeps the page renderable, it is noindex not a redirect', () => {
       const result = getEventSeoStrategy({
         startDate: isoDaysAgo(200),


### PR DESCRIPTION
## What changed

Owner confirmed on 9 August 2026 that drag cabaret nights have stopped and Music Bingo is now the only drag night.

- `docs/SSOT.md` gains a drag cabaret entry under "Retired entertainment formats", alongside open mic.
- `lib/event-seo-strategy.ts` gains a `drag cabaret` token in `DISCONTINUED_FORMATS`, pointing at `/music-bingo`.
- 3 new test cases.

## Why

The three past "Drag Cabaret & Karaoke" pages already fall out of the index, but only incidentally: they sit under the "Nikki's Games Night" category, which is separately discontinued. Nothing encoded the drag cabaret policy itself, so a new drag cabaret event filed under a karaoke category would have started ranking for a night nobody can attend.

This surfaced while reviewing the GSC coverage export. My earlier diagnosis that these events contained a banned SSOT claim was wrong; the cause was category assignment.

## Assumptions

- The token is `drag cabaret`, not `drag`. Music Bingo copy refers to its drag host and must stay indexable. Verified against all 131 event records: the narrower token catches exactly the 3 intended events and leaves "Nikki's Karaoke Night" (which mentions drag but still runs) alone.
- No production data was changed. The existing noindex on those three pages is the correct outcome, so the records were left as they are.

## Testing done

- [x] Manual testing: scanned all 131 event records via the management API to confirm the token's blast radius before adding it.
- [x] Automated tests: 124 suites, 1354 tests pass, including 3 new cases covering the noindex, the replacement link, and the drag-host false-positive guard. SSOT drift guard passes.

## Complexity score

XS

## Breaking changes

None.

## Migration risk

None. No schema, API, or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)