### PR TITLE
feat: collect email on the booking form with a notice instead of tick boxes

### DIFF
--- a/components/CommunicationConsentFields.tsx
+++ b/components/CommunicationConsentFields.tsx
@@ -23,12 +23,19 @@ type CommunicationConsentFieldsProps = {
    * similar night. See GUEST_COMPACT_CONSENT_NOTICE for the reasoning.
    */
   variant?: 'checkboxes' | 'compact'
+  /**
+   * Overrides the compact notice wording. Table bookings pass
+   * GUEST_TABLE_COMPACT_CONSENT_NOTICE, which covers email as well as SMS and names the
+   * unsubscribe link. Ignored by the 'checkboxes' variant.
+   */
+  notice?: string
 }
 
 export function CommunicationConsentFields({
   value,
   onChange,
   variant = 'checkboxes',
+  notice,
 }: CommunicationConsentFieldsProps) {
   const update = (key: keyof CommunicationConsentState, checked: boolean) => {
     onChange({ ...value, [key]: checked })
@@ -40,7 +47,9 @@ export function CommunicationConsentFields({
     // stored record honest: we never claim someone said yes when they were
     // simply never asked.
     return (
-      <p className="text-xs leading-relaxed text-ink-muted">{GUEST_COMPACT_CONSENT_NOTICE}</p>
+      <p className="text-xs leading-relaxed text-ink-muted">
+        {notice ?? GUEST_COMPACT_CONSENT_NOTICE}
+      </p>
     )
   }
 

--- a/components/features/TableBooking/ManagementTableBookingForm.tsx
+++ b/components/features/TableBooking/ManagementTableBookingForm.tsx
@@ -95,6 +95,7 @@ import { getAircraftOverheadNotePartsForDateTime } from '@/lib/heathrow-runway-a
 import { CommunicationConsentFields } from '@/components/CommunicationConsentFields'
 import {
   DEFAULT_COMMUNICATION_CONSENT_STATE,
+  GUEST_TABLE_COMPACT_CONSENT_NOTICE,
   type CommunicationConsentState,
 } from '@/lib/communication-consent'
 import {
@@ -1630,6 +1631,7 @@ export function ManagementTableBookingForm({
       detailsUnlocked,
       isKnownCustomer,
       firstName,
+      email,
       highChairShortfall,
       highChairShortfallAcknowledged,
       selectionRefusedByReading
@@ -2997,6 +2999,7 @@ export function ManagementTableBookingForm({
                     value={email}
                     onChange={(event) => setEmail(event.target.value)}
                     placeholder="name@example.com"
+                    hint="So we can email your confirmation."
                   />
                 </div>
               </div>
@@ -3016,6 +3019,8 @@ export function ManagementTableBookingForm({
               <CommunicationConsentFields
                 value={communicationConsent}
                 onChange={setCommunicationConsent}
+                variant="compact"
+                notice={GUEST_TABLE_COMPACT_CONSENT_NOTICE}
               />
             ) : null}
 
@@ -3224,6 +3229,7 @@ export function ManagementTableBookingForm({
                     value={email}
                     onChange={(event) => setEmail(event.target.value)}
                     placeholder="name@example.com"
+                    hint="So we can email your confirmation."
                   />
                 </div>
               </div>
@@ -3348,6 +3354,8 @@ export function ManagementTableBookingForm({
               <CommunicationConsentFields
                 value={communicationConsent}
                 onChange={setCommunicationConsent}
+                variant="compact"
+                notice={GUEST_TABLE_COMPACT_CONSENT_NOTICE}
               />
             ) : null}
 

--- a/lib/communication-consent.ts
+++ b/lib/communication-consent.ts
@@ -1,4 +1,12 @@
-export const GUEST_COMMS_CONSENT_TEXT_VERSION = 'guest-comms-consent-v1'
+// Bumped to v2 on 2026-08-09, when the table booking form moved to the compact notice
+// and that notice began covering EMAIL as well as SMS. The version is the record of what
+// a guest was actually shown, so it has to move whenever the words do, or a later dispute
+// is settled against wording that guest never saw.
+//
+// Both the client payload and the server sanitiser read this same constant
+// (lib/communication-consent-server.ts pins it with z.literal), so there is exactly one
+// place to change and no way for the two to drift.
+export const GUEST_COMMS_CONSENT_TEXT_VERSION = 'guest-comms-consent-v2'
 
 export const GUEST_SERVICE_CONTACT_NOTICE =
   'We will use your phone and email to manage this booking, including confirmations, reminders, payment links, waitlist updates, and changes.'
@@ -27,6 +35,25 @@ export const GUEST_MARKETING_WHATSAPP_LABEL = 'Send me WhatsApp event and offer 
 // it is simply not offered at booking time rather than quietly assumed.
 export const GUEST_COMPACT_CONSENT_NOTICE =
   'We will use your phone and email to manage this booking, and to text you about upcoming quiz nights, bingo and live music. Reply NOEVENTS to any message to stop event texts.'
+
+// The table-booking version of the same notice, which also covers EMAIL.
+//
+// A sibling constant rather than an edit to the one above, because that one is the record
+// of what event bookers were shown and changing it would rewrite history for consents
+// already stored against it.
+//
+// Two refusal routes are named because there are genuinely two, and a notice that offers
+// only one is not the "simple way to refuse" that soft opt-in requires. NOEVENTS stops
+// texts and is honoured by `marketing_sms_opted_out_at`; the unsubscribe link stops email
+// and is honoured by `marketing_email_opted_out_at`, via /api/unsubscribe in the
+// management app. Neither touches booking confirmations, and the notice says so, because
+// the commonest reason a guest will not give an email address is fear of losing the
+// confirmation for the table they are in the middle of booking.
+//
+// Still deliberately no WhatsApp. Meta's platform rules require explicit opt-in, which
+// soft opt-in does not satisfy, so it is not offered at booking time rather than assumed.
+export const GUEST_TABLE_COMPACT_CONSENT_NOTICE =
+  'We will use your phone and email to manage this booking, and to let you know about upcoming quiz nights, bingo and live music. Reply NOEVENTS to stop texts, or use the unsubscribe link in any email. Booking confirmations and reminders carry on either way.'
 
 export type CommunicationConsentPayload = {
   service_contact_notice_shown: boolean

--- a/lib/table-booking/__tests__/details-step-email.test.ts
+++ b/lib/table-booking/__tests__/details-step-email.test.ts
@@ -1,0 +1,114 @@
+import { findDetailsStepRefusal, type DetailsStepState } from '../journey'
+import {
+  GUEST_COMMS_CONSENT_TEXT_VERSION,
+  GUEST_TABLE_COMPACT_CONSENT_NOTICE,
+} from '@/lib/communication-consent'
+
+/**
+ * Email became worth validating on 2026-08-09, when the booking form started collecting
+ * it on a soft opt-in basis. Before that a typo was just a dead field on one booking.
+ * Now it is a permanently undeliverable address on a marketing list, discovered months
+ * later when a campaign bounces.
+ *
+ * The balance these tests pin: reject the obviously broken, accept anything that might be
+ * real. A guest told their own working address is invalid abandons the booking, which
+ * costs far more than letting an odd-looking address through.
+ */
+
+function state(overrides: Partial<DetailsStepState> = {}): DetailsStepState {
+  return {
+    revalidatingAvailability: false,
+    selectedTime: '19:00',
+    phone: '07700900000',
+    detailsUnlocked: true,
+    isKnownCustomer: false,
+    firstName: 'Jane',
+    email: '',
+    highChairShortfall: null,
+    highChairShortfallAcknowledged: false,
+    selectionRefusedByReading: false,
+    ...overrides,
+  }
+}
+
+describe('email stays optional', () => {
+  it('lets a guest through with no email at all', () => {
+    expect(findDetailsStepRefusal(state({ email: '' }))).toBeNull()
+  })
+
+  it('treats whitespace as empty rather than as a typo', () => {
+    expect(findDetailsStepRefusal(state({ email: '   ' }))).toBeNull()
+  })
+})
+
+describe('a typed email is checked', () => {
+  it.each([
+    ['jane@gmail', 'no dot in the domain'],
+    ['jane.gmail.com', 'no @ at all'],
+    ['@gmail.com', 'nothing before the @'],
+    ['jane@', 'nothing after the @'],
+    ['jane doe@gmail.com', 'a space in the local part'],
+    ['jane@gmail.c', 'a one-character TLD'],
+  ])('refuses %j (%s)', (email) => {
+    const refusal = findDetailsStepRefusal(state({ email }))
+    expect(refusal?.code).toBe('email_invalid')
+  })
+
+  it.each([
+    'jane@gmail.com',
+    'jane.doe@gmail.com',
+    'jane+roast@gmail.com',
+    'jane_doe@sub.domain.co.uk',
+    "o'brien@example.com",
+    'JANE@EXAMPLE.COM',
+  ])('accepts %j', (email) => {
+    expect(findDetailsStepRefusal(state({ email }))).toBeNull()
+  })
+
+  it('asks the guest to fix it or clear it, rather than just saying no', () => {
+    const refusal = findDetailsStepRefusal(state({ email: 'nope' }))
+    expect(refusal?.message).toContain('clear the box')
+  })
+})
+
+describe('email is checked after the things that actually block a booking', () => {
+  it('reports the missing phone first, not the bad email', () => {
+    // Order matters for the guest: the phone is required and the email is not, so
+    // leading with the optional field would read as though the email were the problem.
+    const refusal = findDetailsStepRefusal(state({ phone: '', email: 'nope' }))
+    expect(refusal?.code).toBe('phone_missing')
+  })
+
+  it('reports the missing name before the bad email', () => {
+    const refusal = findDetailsStepRefusal(state({ firstName: '', email: 'nope' }))
+    expect(refusal?.code).toBe('name_missing')
+  })
+
+  it('still refuses a high-chair shortfall that has not been acknowledged', () => {
+    const refusal = findDetailsStepRefusal(
+      state({ email: 'jane@gmail.com', highChairShortfall: { requested: 2, free: 0 } })
+    )
+    expect(refusal?.code).toBe('high_chair_shortfall_unacknowledged')
+  })
+})
+
+describe('the consent notice tells the guest both ways out', () => {
+  it('names the email opt-out as well as the text one', () => {
+    // Soft opt-in requires a simple way to refuse. A notice that mentions only NOEVENTS
+    // covers texts and leaves email with no stated route out at all.
+    expect(GUEST_TABLE_COMPACT_CONSENT_NOTICE).toContain('NOEVENTS')
+    expect(GUEST_TABLE_COMPACT_CONSENT_NOTICE).toContain('unsubscribe')
+  })
+
+  it('promises that booking confirmations keep coming', () => {
+    // The commonest reason a guest withholds an email is fear of losing the confirmation
+    // for the table they are booking right now.
+    expect(GUEST_TABLE_COMPACT_CONSENT_NOTICE).toMatch(/confirmations and reminders carry on/i)
+  })
+
+  it('moved the consent text version, because the wording moved', () => {
+    // The version is the record of what a guest was shown. Leaving it at v1 while the
+    // words change settles a later dispute against wording that guest never saw.
+    expect(GUEST_COMMS_CONSENT_TEXT_VERSION).toBe('guest-comms-consent-v2')
+  })
+})

--- a/lib/table-booking/journey.ts
+++ b/lib/table-booking/journey.ts
@@ -134,6 +134,12 @@ export type DetailsStepState = {
   detailsUnlocked: boolean
   isKnownCustomer: boolean
   firstName: string
+  /**
+   * Optional, and stays optional. Validated only when the guest typed something, because
+   * a typo silently becomes an undeliverable address in the marketing list and there is
+   * no bounce to notice it until a campaign goes out months later.
+   */
+  email: string
   highChairShortfall: HighChairShortfall | null
   highChairShortfallAcknowledged: boolean
   /**
@@ -148,6 +154,17 @@ export type DetailsStepState = {
 }
 
 /** null when the guest may continue; otherwise the reason they may not. */
+/**
+ * Loose shape check: something, an @, something, a dot, something, and no spaces.
+ *
+ * Deliberately not one of the long RFC-shaped regexes. Those reject real addresses, and a
+ * guest who is told their own working email is invalid abandons the booking, which costs
+ * far more than accepting an odd-looking address that turns out to be fine.
+ */
+function isPlausibleEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value)
+}
+
 export function findDetailsStepRefusal(state: DetailsStepState): DetailsStepRefusal | null {
   // A re-read is in flight because they just changed high chairs or outside seating. Their time
   // may be about to be confirmed or replaced, so do not let them submit against it mid-flight.
@@ -191,6 +208,19 @@ export function findDetailsStepRefusal(state: DetailsStepState): DetailsStepRefu
   // surname and the proxy already omits a blank one from the payload).
   if (!state.isKnownCustomer && !state.firstName.trim()) {
     return { code: 'name_missing', message: 'Please enter your first name.' }
+  }
+
+  // Email is optional, so an empty box is fine and always has been. A typed one is
+  // checked, because until now anything at all was accepted: "jane@gmail" and
+  // "jane.gmail.com" both sailed through, went to the management app, and became a
+  // permanently undeliverable address on the marketing list. Nobody finds out until a
+  // campaign bounces months later, and by then the guest is long gone.
+  //
+  // The shape check is deliberately loose. Anything stricter starts rejecting real
+  // addresses, and the cost of a false rejection here (a guest abandons the booking) is
+  // far higher than the cost of letting an odd-but-valid address through.
+  if (state.email.trim() && !isPlausibleEmail(state.email.trim())) {
+    return { code: 'email_invalid', message: 'That email address does not look right. Please check it, or clear the box.' }
   }
 
   // A high-chair shortfall needs an explicit tap before the guest can carry

--- a/tests/unit/ManagementEventBookingForm.test.tsx
+++ b/tests/unit/ManagementEventBookingForm.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { GUEST_COMMS_CONSENT_TEXT_VERSION } from '@/lib/communication-consent'
 import { ManagementEventBookingForm } from '@/components/features/EventBooking/ManagementEventBookingForm'
 import { trackEventBookingComplete } from '@/lib/gtm-events'
 import {
@@ -339,7 +340,7 @@ describe('ManagementEventBookingForm', () => {
         marketing_sms_opt_in: false,
         whatsapp_opt_in: false,
         marketing_whatsapp_opt_in: false,
-        consent_text_version: 'guest-comms-consent-v1'
+        consent_text_version: GUEST_COMMS_CONSENT_TEXT_VERSION
       })
     )
     expect(trackEventBookingComplete).toHaveBeenCalledWith(

--- a/tests/unit/ManagementTableBookingForm.test.tsx
+++ b/tests/unit/ManagementTableBookingForm.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { GUEST_COMMS_CONSENT_TEXT_VERSION } from '@/lib/communication-consent'
 import { ManagementTableBookingForm } from '@/components/features/TableBooking/ManagementTableBookingForm'
 import {
   captureBookingAttributionFromLocation,
@@ -841,7 +842,7 @@ describe('ManagementTableBookingForm', () => {
         marketing_sms_opt_in: false,
         whatsapp_opt_in: false,
         marketing_whatsapp_opt_in: false,
-        consent_text_version: 'guest-comms-consent-v1'
+        consent_text_version: GUEST_COMMS_CONSENT_TEXT_VERSION
       })
     )
   })


### PR DESCRIPTION
Completes the email work whose back half shipped in `the-anchor-management-tools#103`. The unsubscribe route, `List-Unsubscribe` headers and soft opt-in gate are **already live**, so the notice this adds is a true statement rather than a promise nothing can keep. That ordering was deliberate.

## What changed
Replaces the four consent tick boxes on the table booking form with the single compact notice the event form already uses. Same PECR soft opt-in reasoning as the event change and as the SMS audience change of 8 August.

## Why a sibling constant, not an edit
`GUEST_COMPACT_CONSENT_NOTICE` is the record of what **event** bookers were shown. Editing it would rewrite history for consents already stored against it. The new `GUEST_TABLE_COMPACT_CONSENT_NOTICE` covers email as well as SMS and names **both** refusal routes, because there genuinely are two:

| Route | Stops | Honoured by |
|---|---|---|
| Reply NOEVENTS | texts | `marketing_sms_opted_out_at` |
| Unsubscribe link | email | `marketing_email_opted_out_at` |

A notice offering only one is not the "simple way to refuse" soft opt-in requires. It also promises booking confirmations carry on regardless, because the commonest reason a guest withholds an email is fear of losing the confirmation for the table they are booking right then.

## Consent version
Moves to `v2`. The version records what a guest was shown, so leaving it at v1 while the words change would settle a later dispute against wording that guest never saw. Client and server read the same constant, so they cannot drift. Two tests that hardcoded v1 now read the constant.

## Email validation, which did not exist at all
`jane@gmail` and `jane.gmail.com` were both accepted and became permanently undeliverable addresses, discovered months later when a campaign bounces. The check is deliberately loose: a guest told their own working address is invalid abandons the booking, which costs more than an odd-but-valid address getting through. Email stays optional, and is checked **after** phone and name so the optional field never reads as the blocker.

## Deliberately NOT changed
- `DEFAULT_COMMUNICATION_CONSENT_STATE`, shared with the private-hire and parking forms where soft opt-in does not obviously apply.
- The returning-customer path, which never shows the email field at all, so your most loyal guests still contribute no addresses. Worth its own change.

## Testing done
- [x] 1,375 tests pass including 21 new ones covering the boundary (empty and whitespace accepted, six broken shapes refused, six real-world shapes accepted including plus-addressing and an apostrophe), the refusal ordering, and the notice wording.
- [x] Lint clean (hero and menu-page audits pass), `tsc --noEmit` clean, production build passes.
- [x] Checked in a mobile viewport that no stray consent checkboxes render.

## Complexity score
S

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)