### PR TITLE
fix: stop hiding the booking button and interrupting the booking form

### DIFF
--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { 
   hasUserConsented, 
@@ -13,11 +13,55 @@ import {
 import { trackCookieConsent } from '@/lib/gtm-events';
 import { Button } from '@/components/ui';
 
+/**
+ * Published so the sticky Book a table bar can sit directly above this banner instead of
+ * hiding until it is dismissed. Both are pinned to the bottom of the viewport, so without
+ * a shared measurement one has to give way, and until now it was the booking button: a
+ * first-time visitor could not see it at all until they answered the cookie prompt.
+ *
+ * A CSS variable rather than React state because the two components have no common
+ * ancestor that re-renders, and the height is genuinely a layout fact rather than
+ * application state. Measured rather than hardcoded because the banner wraps to two lines
+ * on narrow screens and grows again when the preferences panel opens.
+ */
+const BANNER_HEIGHT_VAR = '--cookie-banner-height';
+
 export default function CookieBanner() {
   const [showBanner, setShowBanner] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [consent, setConsent] = useState<CookieConsent | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const clear = () => root.style.setProperty(BANNER_HEIGHT_VAR, '0px');
+
+    if (!showBanner) {
+      clear();
+      return;
+    }
+
+    const node = bannerRef.current;
+    if (!node) return;
+
+    const publish = () => {
+      root.style.setProperty(BANNER_HEIGHT_VAR, `${node.offsetHeight}px`);
+    };
+    publish();
+
+    // The banner changes height when it wraps or when preferences expand, and the sticky
+    // bar has to move with it rather than overlap it halfway through a transition.
+    const observer = new ResizeObserver(publish);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+      // Always reset on unmount. Leaving a stale height would push the sticky bar up off
+      // the bottom of the screen on every subsequent page with no banner in sight.
+      clear();
+    };
+  }, [showBanner, showPreferences]);
 
   useEffect(() => {
     // Check if user has already consented
@@ -68,7 +112,12 @@ export default function CookieBanner() {
   return (
     <>
       {/* Main Banner - Mobile-optimized with collapsible design */}
-      <div className="fixed bottom-0 left-0 right-0 bg-surface border-t border-line shadow-lg z-[80] animate-slide-up safe-area-inset-bottom">
+      {/* z-[90] keeps the banner above the sticky CTA bar (z-[80]), which now sits directly
+          on top of it rather than waiting for it to be dismissed. */}
+      <div
+        ref={bannerRef}
+        className="fixed bottom-0 left-0 right-0 bg-surface border-t border-line shadow-lg z-[90] animate-slide-up safe-area-inset-bottom"
+      >
         <div className="max-w-7xl mx-auto px-3 py-2 sm:px-6 sm:py-3 lg:px-8">
           {/* Mobile: Compact single-line design */}
           <div className="sm:hidden">

--- a/components/features/christmas/ChristmasLightbox.tsx
+++ b/components/features/christmas/ChristmasLightbox.tsx
@@ -16,9 +16,38 @@ const SUPPRESSION_DAYS = 365
 const CAMPAIGN_START = new Date('2026-08-01T00:00:00').getTime()
 const CAMPAIGN_END = new Date('2026-12-15T23:59:59').getTime()
 
+/**
+ * Routes where the lightbox must never fire.
+ *
+ * /christmas-parties is the obvious one: it advertises the thing you are already reading.
+ *
+ * The booking routes matter more. Interrupting somebody who is part-way through choosing
+ * a time and typing their phone number is the single worst moment to cover the screen: it
+ * costs a booking that was already most of the way to done, in exchange for a click
+ * through to an enquiry form. The lightbox also sets its suppression key the moment it
+ * opens, so a guest interrupted mid-booking has additionally burned the one showing they
+ * were going to get all season.
+ *
+ * Prefix matching, because these journeys have sub-steps and query strings, and an exact
+ * match would let the modal reappear one step into the flow.
+ */
+const SUPPRESSED_ROUTE_PREFIXES = [
+    '/christmas-parties',
+    '/book-table',
+    '/book-event',
+    '/booking-confirmation',
+] as const
+
+export function isLightboxSuppressedRoute(pathname: string | null): boolean {
+    if (!pathname) return false
+    return SUPPRESSED_ROUTE_PREFIXES.some(
+        (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+    )
+}
+
 export function ChristmasLightbox() {
     const pathname = usePathname()
-    const isChristmasPage = pathname === '/christmas-parties'
+    const isSuppressedRoute = isLightboxSuppressedRoute(pathname)
     const [isOpen, setIsOpen] = useState(false)
     const [hasINTERACTED, setHasINTERACTED] = useState(false)
     const [isVisible, setIsVisible] = useState(false)
@@ -29,7 +58,7 @@ export function ChristmasLightbox() {
 
     const checkSuppression = useCallback(() => {
         if (typeof window === 'undefined') return true
-        if (isChristmasPage) return true
+        if (isSuppressedRoute) return true
 
         // Check date range
         const now = Date.now()
@@ -40,7 +69,7 @@ export function ChristmasLightbox() {
 
         // If seen, suppress for the rest of the season
         return true
-    }, [isChristmasPage])
+    }, [isSuppressedRoute])
 
 	    const triggerLightbox = useCallback((trigger?: 'timer' | 'exit_intent') => {
 	        if (checkSuppression() || hasINTERACTED) return

--- a/components/features/christmas/__tests__/lightbox-suppression.test.ts
+++ b/components/features/christmas/__tests__/lightbox-suppression.test.ts
@@ -1,0 +1,54 @@
+import { isLightboxSuppressedRoute } from '../ChristmasLightbox'
+
+/**
+ * The lightbox burns its once-per-season suppression key the moment it opens, so firing it
+ * on a booking page costs twice: the booking in progress, and the one showing that guest
+ * was ever going to get.
+ */
+
+describe('the lightbox never fires mid-booking', () => {
+  it.each([
+    '/book-table',
+    '/book-event',
+    '/booking-confirmation',
+  ])('is suppressed on %s', (path) => {
+    expect(isLightboxSuppressedRoute(path)).toBe(true)
+  })
+
+  it.each([
+    ['/book-table/confirm', 'a booking sub-step'],
+    ['/book-event/quiz-night', 'an event booking sub-step'],
+    ['/booking-confirmation/abc123', 'a confirmation with a reference'],
+  ])('is suppressed on %s (%s)', (path) => {
+    // Exact matching would let the modal reappear one step into the flow, which is worse
+    // than never suppressing it: the guest has invested more by then.
+    expect(isLightboxSuppressedRoute(path)).toBe(true)
+  })
+
+  it('is suppressed on the page it advertises', () => {
+    expect(isLightboxSuppressedRoute('/christmas-parties')).toBe(true)
+  })
+})
+
+describe('it still fires everywhere it should', () => {
+  it.each([
+    '/',
+    '/sunday-roast',
+    '/food-menu',
+    '/whats-on',
+    '/private-hire',
+    '/beer-garden',
+  ])('is allowed on %s', (path) => {
+    expect(isLightboxSuppressedRoute(path)).toBe(false)
+  })
+
+  it('does not suppress a route that merely starts with the same letters', () => {
+    // '/book-table-something' is not inside the booking journey. Guarding with a bare
+    // startsWith and no boundary would have swallowed it.
+    expect(isLightboxSuppressedRoute('/book-tables-guide')).toBe(false)
+  })
+
+  it('handles a null pathname without throwing', () => {
+    expect(isLightboxSuppressedRoute(null)).toBe(false)
+  })
+})

--- a/components/layout/StickyCtas.tsx
+++ b/components/layout/StickyCtas.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { hasUserConsented } from '@/lib/cookies'
 import { Utensils, Phone, MessageCircle } from 'lucide-react'
 import { Button } from '@/components/ui'
 import {
@@ -13,7 +14,6 @@ import {
   trackStickyCtaShown,
   trackCtaClick
 } from '@/lib/gtm-events'
-import { hasUserConsented } from '@/lib/cookies'
 
 // StickyCtas (spec §5.4): the single global sticky CTA bar that replaces every
 // page-level/floating CTA. Fixed to the bottom, full width, revealed only once the
@@ -55,7 +55,15 @@ export function StickyCtas() {
   const [visible, setVisible] = useState(false)
   const [cookieBannerVisible, setCookieBannerVisible] = useState(false)
   const [deviceType, setDeviceType] = useState<DeviceType>('unknown')
-  const showStickyCtas = visible && !cookieBannerVisible
+
+  // The bar used to hide itself entirely while the cookie banner was up, because both are
+  // pinned to the bottom of the viewport and would have overlapped. The cost of that was
+  // silent and large: a first-time visitor, the exact person most in need of an obvious
+  // way to book, could not see the button at all until they answered a cookie prompt.
+  //
+  // The banner is still tracked, but now only to position this bar on top of it rather
+  // than to suppress it. No consent is required to render a link.
+  const showStickyCtas = visible
   const heroHeightRef = useRef<number>(HERO_FALLBACK_HEIGHT)
   const visibleSinceRef = useRef<number | null>(null)
   const deviceTypeRef = useRef<DeviceType>('unknown')
@@ -134,8 +142,18 @@ export function StickyCtas() {
   return (
     <div
       aria-hidden={!showStickyCtas}
-      className="fixed inset-x-0 bottom-0 z-[80] border-t border-line bg-[rgba(255,255,255,0.96)] py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom,0px))] backdrop-blur transition-transform duration-[var(--dur)] ease-[var(--ease-out)] supports-[backdrop-filter]:backdrop-blur"
+      className="fixed inset-x-0 z-[80] border-t border-line bg-[rgba(255,255,255,0.96)] py-3 backdrop-blur transition-[transform,bottom] duration-[var(--dur)] ease-[var(--ease-out)] supports-[backdrop-filter]:backdrop-blur"
       style={{
+        // Rides on top of the cookie banner while it is up, then drops back to the bottom
+        // edge once it is dismissed. Defaults to 0px so every page with no banner renders
+        // exactly as before.
+        bottom: cookieBannerVisible ? 'var(--cookie-banner-height, 0px)' : 0,
+        // The safe-area inset belongs to whichever element actually touches the bottom
+        // edge, which is the banner whenever there is one. Keeping it here as well would
+        // open a phantom gap inside the bar on notched phones.
+        paddingBottom: cookieBannerVisible
+          ? '0.75rem'
+          : 'calc(0.75rem + env(safe-area-inset-bottom, 0px))',
         transform: showStickyCtas ? 'translateY(0)' : 'translateY(125%)',
         boxShadow: '0 -6px 24px rgba(26,26,26,0.10)'
       }}

--- a/tests/unit/sticky-ctas-cookie-banner.test.ts
+++ b/tests/unit/sticky-ctas-cookie-banner.test.ts
@@ -1,0 +1,73 @@
+import fs from 'fs'
+import path from 'path'
+
+const STICKY = fs.readFileSync(
+  path.join(process.cwd(), 'components/layout/StickyCtas.tsx'),
+  'utf8'
+)
+const BANNER = fs.readFileSync(
+  path.join(process.cwd(), 'components/CookieBanner.tsx'),
+  'utf8'
+)
+
+/**
+ * Source-level guards, because the thing worth protecting is a decision rather than a
+ * rendered pixel: the sticky bar must never again make itself invisible because another
+ * fixed element is on screen.
+ *
+ * The original code read `visible && !cookieBannerVisible`. It looked like collision
+ * avoidance and behaved like a conversion leak, because the person who has not answered
+ * the cookie prompt is by definition a first-time visitor: exactly the one who most needs
+ * an obvious way to book, and the one guaranteed not to see it.
+ *
+ * A DOM test cannot catch a regression here. Both elements are position:fixed and the
+ * failure is that one of them is simply absent, which renders as a perfectly valid page.
+ */
+
+describe('the cookie banner never suppresses the booking bar', () => {
+  it('does not gate visibility on the cookie banner', () => {
+    expect(STICKY).not.toMatch(/showStickyCtas\s*=\s*visible\s*&&\s*!\s*cookieBannerVisible/)
+  })
+
+  it('shows whenever the page has scrolled past the hero, and on no other condition', () => {
+    expect(STICKY).toMatch(/const showStickyCtas = visible\b/)
+  })
+
+  it('still tracks the banner, but only to position itself', () => {
+    // The flag is legitimate: it decides the offset and which element owns the safe-area
+    // inset. It must not creep back into the visibility expression.
+    expect(STICKY).toContain('cookieBannerVisible')
+    expect(STICKY).toMatch(/bottom: cookieBannerVisible/)
+  })
+})
+
+describe('the two bars are positioned from one shared measurement', () => {
+  it('offsets the bar by the height the banner publishes', () => {
+    expect(STICKY).toContain('var(--cookie-banner-height, 0px)')
+  })
+
+  it('publishes that height from the banner, measured rather than hardcoded', () => {
+    // The banner wraps to two lines on narrow screens and grows again when preferences
+    // expand. A hardcoded height would overlap on exactly the phones that matter most.
+    expect(BANNER).toContain('--cookie-banner-height')
+    expect(BANNER).toContain('offsetHeight')
+    expect(BANNER).toContain('ResizeObserver')
+  })
+
+  it('resets the height when the banner goes away', () => {
+    // A stale value would push the bar up off the bottom edge on every later page.
+    expect(BANNER).toMatch(/setProperty\(BANNER_HEIGHT_VAR, '0px'\)/)
+  })
+
+  it('keeps the banner layered above the bar', () => {
+    // The bar sits on top of the banner, so the banner must win any overlap during the
+    // slide transition.
+    expect(BANNER).toMatch(/z-\[90\]/)
+    expect(STICKY).toMatch(/z-\[80\]/)
+  })
+
+  it('gives the safe-area inset to whichever element touches the bottom edge', () => {
+    // Applying it in both places opens a visible gap inside the bar on notched phones.
+    expect(STICKY).toMatch(/paddingBottom: cookieBannerVisible/)
+  })
+})


### PR DESCRIPTION
Two separate ways the site was getting between a guest and a booking.

## 1. The sticky Book a table bar hid itself whenever the cookie banner was up

`showStickyCtas = visible && !cookieBannerVisible`. Both elements are pinned to the bottom with the same z-index, so one had to give way, and the one that gave way was the booking button.

The person who has not yet answered the cookie prompt is **by definition a first-time visitor**: exactly the one who most needs an obvious way to book, and the one guaranteed not to see it. No consent is required to render a link.

The bar now sits directly on top of the banner. The banner measures itself and publishes `--cookie-banner-height`; the bar offsets by it. Measured rather than hardcoded because the banner wraps to two lines on narrow screens and grows again when preferences expand, so a fixed number would overlap on exactly the phones that matter most. A `ResizeObserver` keeps them in step mid-transition, and the height resets to 0 on unmount, since a stale value would push the bar off the bottom edge on every later page.

The safe-area inset moves to whichever element actually touches the bottom edge. Keeping it in both opens a visible gap inside the bar on notched phones.

## 2. The Christmas lightbox fired on the booking pages

Covering the screen while somebody is choosing a time and typing their phone number is the worst possible moment: it costs a booking that was nearly done, in exchange for a click through to an enquiry form.

Worse, the lightbox writes its once-per-season suppression key **the moment it opens**, so an interrupted guest also burns the one showing they were ever going to get.

Now suppressed across `/book-table`, `/book-event` and `/booking-confirmation` as well as `/christmas-parties`. Prefix matching with a boundary, because these journeys have sub-steps and an exact match would let the modal reappear one step into the flow, which is worse than never suppressing it.

## Testing done
- [x] 1,398 tests pass, 23 new. Lint clean, `tsc --noEmit` clean, production build passes.
- [x] Verified in a 375px viewport that the banner publishes a real measured height (65px) and the bar's offset resolves against it.

**On the sticky-bar tests being source-level:** both elements are `position: fixed` and the failure mode is that one is simply *absent*, which renders as a perfectly valid page. A DOM assertion would not have caught the original regression and would not catch its return.

## Complexity score
S

## Breaking changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)