### PR TITLE
feat: book a table from the sticky bar without leaving the page

### DIFF
--- a/app/live-sport/world-cup/page.tsx
+++ b/app/live-sport/world-cup/page.tsx
@@ -291,7 +291,7 @@ export default async function WorldCupPage() {
                 <ul className="mt-4 space-y-2 text-sm text-ink-muted">
                   <li>Book any showing match now</li>
                   <li>No deposits for groups under 15</li>
-                  <li>Groups of 10+: £10 per person deposit, deducted from your bill</li>
+                  <li>Groups of 15+: £10 per person deposit, deducted from your bill</li>
                   <li>Large groups: book early for the best tables</li>
                   <li>Tables are held until kick-off, then released</li>
                 </ul>

--- a/app/private-hire/near/[slug]/page.tsx
+++ b/app/private-hire/near/[slug]/page.tsx
@@ -34,7 +34,7 @@ export async function generateStaticParams() {
 // the FAQ all vary by what kind of place the landmark is. Every fact used here
 // is grounded in docs/SSOT.md (capacity 10+ to 150; dining room seats 26; 250
 // venue max; 20 free parking spaces; £250 private deposit; £10pp deposit for
-// groups of 10+; TVs and a sound system, no projector; dedicated events
+// groups of 15+; TVs and a sound system, no projector; dedicated events
 // coordinator; ~7 minutes from Heathrow Terminal 5; outside the ULEZ;
 // dog-friendly garden). No food or drink prices are quoted (those are live).
 // Distances come only from the landmark dataset, never invented door-to-door.
@@ -287,7 +287,7 @@ function getLandmarkAngle(landmark: Landmark): LandmarkAngle {
                     },
                     {
                         question: 'Is a deposit required?',
-                        answer: 'For groups of ten or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit. Call us to confirm the details.',
+                        answer: 'For groups of 15 or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit. Call us to confirm the details.',
                     },
                 ],
             }
@@ -348,7 +348,7 @@ function getLandmarkAngle(landmark: Landmark): LandmarkAngle {
                     },
                     {
                         question: 'Is a deposit required?',
-                        answer: 'For groups of ten or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
+                        answer: 'For groups of 15 or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
                     },
                     {
                         question: 'Is the garden available?',
@@ -417,7 +417,7 @@ function getLandmarkAngle(landmark: Landmark): LandmarkAngle {
                     },
                     {
                         question: 'Is a deposit required?',
-                        answer: 'For groups of ten or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
+                        answer: 'For groups of 15 or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
                     },
                 ],
             }
@@ -482,7 +482,7 @@ function getLandmarkAngle(landmark: Landmark): LandmarkAngle {
                     },
                     {
                         question: 'Is a deposit required?',
-                        answer: 'For groups of ten or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
+                        answer: 'For groups of 15 or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
                     },
                 ],
             }
@@ -547,7 +547,7 @@ function getLandmarkAngle(landmark: Landmark): LandmarkAngle {
                     },
                     {
                         question: 'Is a deposit required?',
-                        answer: 'For groups of ten or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
+                        answer: 'For groups of 15 or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
                     },
                 ],
             }
@@ -614,7 +614,7 @@ function getLandmarkAngle(landmark: Landmark): LandmarkAngle {
                     },
                     {
                         question: 'Is a deposit required?',
-                        answer: 'For groups of ten or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
+                        answer: 'For groups of 15 or more, a deposit of £10 per person applies and is fully deducted from your final bill on the day. Smaller groups can book without a deposit.',
                     },
                 ],
             }

--- a/components/features/TableBooking/QuickBookSheet.tsx
+++ b/components/features/TableBooking/QuickBookSheet.tsx
@@ -1,0 +1,547 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@/components/ui/primitives/Button'
+import { Input } from '@/components/ui/primitives/Input'
+import { StickyDrawer } from '@/components/ui/overlays/StickyDrawer'
+import { GUEST_TABLE_COMPACT_CONSENT_NOTICE } from '@/lib/communication-consent'
+import {
+  fetchAvailability,
+  NEUTRAL_AVAILABILITY_ANCHOR_TIME,
+  busynessCaption,
+  type AvailabilityData,
+} from '@/lib/table-booking/availability'
+import {
+  DEFAULT_PARTY_SIZE,
+  QUICK_BOOK_MAX_PARTY,
+  buildQuickBookPayload,
+  defaultQuickBookState,
+  findQuickBookRefusal,
+  fullFormHref,
+  quickDateChoices,
+  resolveEmptyState,
+  selectableSlots,
+  type QuickBookState,
+} from '@/lib/table-booking/quick-book'
+import {
+  trackTableBookingClick,
+  trackFormStart,
+  trackFormComplete,
+  trackBookingErrorShown,
+} from '@/lib/gtm-events'
+
+type QuickBookSheetProps = {
+  open: boolean
+  onClose: () => void
+  /** Where the sheet was opened from, for attribution. */
+  source: string
+}
+
+type Phase = 'choose' | 'details' | 'done'
+
+/**
+ * Two taps and a phone number.
+ *
+ * The full wizard at /book-table asks the right questions for a complicated booking:
+ * high chairs, accessible tables, outside seating, deposits, seasonal menus. For the
+ * ordinary case, a table for two tonight, all of that is friction between a guest and a
+ * booking they had already decided to make.
+ *
+ * So this sheet does not reimplement the wizard, it short-circuits it. Everything it can
+ * assume, it assumes; everything it cannot, it hands to the full form with the guest's
+ * answers carried across. It deliberately owns NO business rules of its own: availability,
+ * purpose and validation all come from the same modules the wizard uses, so the two cannot
+ * drift into disagreeing about what is bookable.
+ */
+export function QuickBookSheet({ open, onClose, source }: QuickBookSheetProps) {
+  const [state, setState] = useState<QuickBookState>(defaultQuickBookState)
+  const [phase, setPhase] = useState<Phase>('choose')
+  const [availability, setAvailability] = useState<AvailabilityData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [selectedTime, setSelectedTime] = useState<string | null>(null)
+  const [phone, setPhone] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [fieldError, setFieldError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [reference, setReference] = useState<string | null>(null)
+
+  const dateChoices = useMemo(() => quickDateChoices(), [])
+  const phoneRef = useRef<HTMLInputElement | null>(null)
+  const startedRef = useRef(false)
+
+  // A fresh sheet every time it opens. Reopening after a booking and finding the previous
+  // guest's phone number still in the box is alarming on a shared family phone.
+  useEffect(() => {
+    if (open) return
+    setState(defaultQuickBookState())
+    setPhase('choose')
+    setSelectedTime(null)
+    setPhone('')
+    setFirstName('')
+    setError(null)
+    setFieldError(null)
+    setReference(null)
+    startedRef.current = false
+  }, [open])
+
+  useEffect(() => {
+    if (!open || startedRef.current) return
+    startedRef.current = true
+    trackFormStart({ formName: 'quick_book_sheet', formLocation: source })
+  }, [open, source])
+
+  // Availability loads the moment the sheet opens, and again whenever a chip changes, so
+  // the times are usually on screen before the guest has finished reading the chips.
+  useEffect(() => {
+    if (!open) return
+
+    const controller = new AbortController()
+    let cancelled = false
+
+    setLoading(true)
+    setError(null)
+
+    fetchAvailability(
+      {
+        date: state.date,
+        time: NEUTRAL_AVAILABILITY_ANCHOR_TIME,
+        partySize: state.partySize,
+        drinksOnly: state.purpose === 'drinks',
+        // The sheet never asks about these, which is exactly why it hands over to the full
+        // form when they might matter. Sending the neutral answer keeps the availability
+        // question identical to the one the wizard asks with nothing selected.
+        isOutsideSeating: false,
+        requiresAccessibleTable: false,
+        highChairCount: 0,
+      },
+      controller.signal
+    )
+      .then((data) => {
+        if (cancelled) return
+        setAvailability(data)
+      })
+      .catch((failure: unknown) => {
+        if (cancelled || controller.signal.aborted) return
+        setAvailability(null)
+        setError(
+          failure instanceof Error
+            ? failure.message
+            : 'We could not check availability right now.'
+        )
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [open, state.date, state.partySize, state.purpose])
+
+  const slots = useMemo(
+    () => selectableSlots(availability, state.partySize, state.purpose),
+    [availability, state.partySize, state.purpose]
+  )
+  const emptyState = useMemo(
+    () => resolveEmptyState(availability, state.partySize, state.purpose, loading),
+    [availability, state.partySize, state.purpose, loading]
+  )
+
+  const updateState = useCallback((patch: Partial<QuickBookState>) => {
+    // Changing a chip invalidates the chosen time: it belonged to a different question.
+    setSelectedTime(null)
+    setState((current) => ({ ...current, ...patch }))
+  }, [])
+
+  const chooseTime = useCallback((time: string) => {
+    setSelectedTime(time)
+    setPhase('details')
+    setFieldError(null)
+    // Focus after the phase transition so the keyboard opens straight onto the number.
+    setTimeout(() => phoneRef.current?.focus(), 60)
+  }, [])
+
+  const submit = useCallback(async () => {
+    const refusal = findQuickBookRefusal({ time: selectedTime, phone, firstName })
+    if (refusal) {
+      setFieldError(refusal.message)
+      trackBookingErrorShown({ code: `quick_book_${refusal.field}` })
+      return
+    }
+
+    const slot = slots.find((candidate) => candidate.time === selectedTime)
+    if (!slot) {
+      // The grid moved under them while they typed. Send them back rather than book a
+      // time that is no longer offered.
+      setPhase('choose')
+      setSelectedTime(null)
+      setError('That time has just gone. Please pick another.')
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const payload = buildQuickBookPayload({
+        state,
+        time: selectedTime as string,
+        slotPurpose: slot.bookable_purpose,
+        phone,
+        firstName,
+      })
+
+      const response = await fetch('/api/table-bookings', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // Scoped to this attempt's actual content, so a double tap cannot create two
+          // bookings but a genuine retry after a change still can.
+          'Idempotency-Key': `quickbook-${payload.phone}-${payload.date}-${payload.time}-${payload.party_size}`,
+        },
+        body: JSON.stringify(payload),
+      })
+
+      const body = await response.json()
+      const data = body?.data || body
+
+      if (!response.ok || body?.success === false) {
+        throw new Error(
+          body?.error?.message ||
+            body?.error ||
+            data?.error ||
+            'We could not complete your booking. Please try again or give us a ring.'
+        )
+      }
+
+      setReference(data?.booking_reference || null)
+      setPhase('done')
+      trackFormComplete({ formName: 'quick_book_sheet', formLocation: source })
+      trackTableBookingClick({ source: `quick_book_${source}`, context: 'quick_book' })
+    } catch (failure: unknown) {
+      setError(
+        failure instanceof Error
+          ? failure.message
+          : 'We could not complete your booking. Please try again or give us a ring.'
+      )
+      trackBookingErrorShown({ code: 'quick_book_submit_failed' })
+    } finally {
+      setSubmitting(false)
+    }
+  }, [firstName, phone, selectedTime, slots, source, state])
+
+  return (
+    <StickyDrawer
+      open={open}
+      onClose={onClose}
+      side="bottom"
+      title={phase === 'done' ? 'Table booked' : 'Book a table'}
+    >
+      <div className="space-y-4 px-4 pb-6 pt-2">
+        {phase === 'done' ? (
+          <div className="space-y-3 text-center">
+            <p className="text-lg font-semibold text-ink-strong">You&apos;re booked in.</p>
+            <p className="text-sm text-ink-muted">
+              {formatConfirmation(state, selectedTime)}
+            </p>
+            {reference ? (
+              <p className="text-sm text-ink-muted">
+                Reference <strong className="text-ink-strong">{reference}</strong>
+              </p>
+            ) : null}
+            <p className="text-xs text-ink-muted">We&apos;ve sent a confirmation by text.</p>
+            <Button variant="primary" size="lg" className="w-full" onClick={onClose}>
+              Done
+            </Button>
+          </div>
+        ) : (
+          <>
+            <ChipRow
+              state={state}
+              dateChoices={dateChoices}
+              onChange={updateState}
+              disabled={submitting}
+            />
+
+            {phase === 'choose' ? (
+              <TimeGrid
+                slots={slots}
+                emptyState={emptyState}
+                state={state}
+                error={error}
+                onChoose={chooseTime}
+                onSwitchToDrinks={() => updateState({ purpose: 'drinks' })}
+              />
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm text-ink-muted">
+                  {formatConfirmation(state, selectedTime)}{' '}
+                  <button
+                    type="button"
+                    className="underline"
+                    onClick={() => {
+                      setPhase('choose')
+                      setFieldError(null)
+                    }}
+                  >
+                    Change
+                  </button>
+                </p>
+
+                <Input
+                  ref={phoneRef}
+                  label="Mobile number"
+                  type="tel"
+                  size="lg"
+                  inputMode="tel"
+                  autoComplete="tel"
+                  value={phone}
+                  onChange={(event) => setPhone(event.target.value)}
+                  placeholder="07700 900000"
+                  hint="So we can text your confirmation."
+                />
+
+                <Input
+                  label="First name"
+                  size="lg"
+                  autoComplete="given-name"
+                  value={firstName}
+                  onChange={(event) => setFirstName(event.target.value)}
+                  placeholder="Jane"
+                />
+
+                {fieldError ? (
+                  <p className="text-sm text-anchor-danger">{fieldError}</p>
+                ) : null}
+                {error ? <p className="text-sm text-anchor-danger">{error}</p> : null}
+
+                <Button
+                  variant="primary"
+                  size="lg"
+                  className="w-full"
+                  loading={submitting}
+                  onClick={submit}
+                >
+                  Book table
+                </Button>
+
+                <p className="text-xs leading-relaxed text-ink-muted">
+                  {GUEST_TABLE_COMPACT_CONSENT_NOTICE}
+                </p>
+              </div>
+            )}
+
+            <p className="text-center text-xs text-ink-muted">
+              Need high chairs, outside seating or a bigger table?{' '}
+              <Link
+                href={fullFormHref({ ...state, time: selectedTime })}
+                className="underline"
+                onClick={onClose}
+              >
+                Use the full form
+              </Link>
+              .
+            </p>
+          </>
+        )}
+      </div>
+    </StickyDrawer>
+  )
+}
+
+function formatConfirmation(state: QuickBookState, time: string | null): string {
+  const people = `${state.partySize} ${state.partySize === 1 ? 'person' : 'people'}`
+  const when = new Date(`${state.date}T00:00:00Z`).toLocaleDateString('en-GB', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+  })
+  return time ? `${people}, ${when} at ${time}.` : `${people}, ${when}.`
+}
+
+function ChipRow({
+  state,
+  dateChoices,
+  onChange,
+  disabled,
+}: {
+  state: QuickBookState
+  dateChoices: { value: string; label: string }[]
+  onChange: (patch: Partial<QuickBookState>) => void
+  disabled: boolean
+}) {
+  return (
+    <div className="space-y-3">
+      <fieldset disabled={disabled}>
+        <legend className="sr-only">Party size</legend>
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: QUICK_BOOK_MAX_PARTY }, (_, index) => index + 1).map((size) => (
+            <Chip
+              key={size}
+              selected={state.partySize === size}
+              onClick={() => onChange({ partySize: size })}
+              label={String(size)}
+              ariaLabel={`${size} ${size === 1 ? 'person' : 'people'}`}
+            />
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset disabled={disabled}>
+        <legend className="sr-only">Date</legend>
+        <div className="flex flex-wrap gap-2">
+          {dateChoices.map((choice) => (
+            <Chip
+              key={choice.value}
+              selected={state.date === choice.value}
+              onClick={() => onChange({ date: choice.value })}
+              label={choice.label}
+            />
+          ))}
+          <label className="sr-only" htmlFor="quick-book-date">
+            Another date
+          </label>
+          <input
+            id="quick-book-date"
+            type="date"
+            value={state.date}
+            min={dateChoices[0]?.value}
+            onChange={(event) => onChange({ date: event.target.value })}
+            className="rounded-full border border-line px-3 py-2 text-sm text-ink"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset disabled={disabled}>
+        <legend className="sr-only">Eating or drinks</legend>
+        <div className="flex flex-wrap gap-2">
+          <Chip
+            selected={state.purpose === 'food'}
+            onClick={() => onChange({ purpose: 'food' })}
+            label="Eating"
+          />
+          <Chip
+            selected={state.purpose === 'drinks'}
+            onClick={() => onChange({ purpose: 'drinks' })}
+            label="Just drinks"
+          />
+        </div>
+      </fieldset>
+    </div>
+  )
+}
+
+function Chip({
+  selected,
+  onClick,
+  label,
+  ariaLabel,
+}: {
+  selected: boolean
+  onClick: () => void
+  label: string
+  ariaLabel?: string
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={[
+        'min-h-[44px] min-w-[44px] rounded-full border px-4 text-sm transition-colors',
+        selected
+          ? 'border-accent bg-accent text-canvas'
+          : 'border-line bg-surface text-ink hover:border-accent',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  )
+}
+
+function TimeGrid({
+  slots,
+  emptyState,
+  state,
+  error,
+  onChoose,
+  onSwitchToDrinks,
+}: {
+  slots: ReturnType<typeof selectableSlots>
+  emptyState: ReturnType<typeof resolveEmptyState>
+  state: QuickBookState
+  error: string | null
+  onChoose: (time: string) => void
+  onSwitchToDrinks: () => void
+}) {
+  if (emptyState === 'loading') {
+    return <p className="py-6 text-center text-sm text-ink-muted">Checking times…</p>
+  }
+
+  if (emptyState === 'check_failed' || error) {
+    return (
+      <div className="space-y-2 py-4 text-center">
+        <p className="text-sm text-ink-muted">
+          {error || 'We could not check times just now.'}
+        </p>
+        <a href="tel:+441753682707" className="text-sm underline">
+          Ring us on 01753 682707
+        </a>
+      </div>
+    )
+  }
+
+  if (emptyState === 'kitchen_closed_but_drinks_available') {
+    return (
+      <div className="space-y-3 py-4 text-center">
+        {/* The recovery that matters. Mondays the kitchen is shut but the bar is open, and
+            a guest told "no availability" walks away from a table they could have had. */}
+        <p className="text-sm text-ink-muted">
+          The kitchen is closed then, but we can seat you for drinks.
+        </p>
+        <Button variant="outline" size="md" onClick={onSwitchToDrinks}>
+          Show drinks times
+        </Button>
+      </div>
+    )
+  }
+
+  if (emptyState === 'nothing_today') {
+    return (
+      <div className="space-y-2 py-4 text-center">
+        <p className="text-sm text-ink-muted">
+          Nothing free for {state.partySize} then. Try another day, or give us a ring.
+        </p>
+        <a href="tel:+441753682707" className="text-sm underline">
+          Ring us on 01753 682707
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+      {slots.map((slot) => {
+        const caption = busynessCaption(slot.busyness)
+        return (
+          <button
+            key={slot.time}
+            type="button"
+            onClick={() => onChoose(slot.time)}
+            className="min-h-[48px] rounded-md border border-line bg-surface px-2 py-2 text-sm text-ink transition-colors hover:border-accent hover:bg-surface-sunk"
+          >
+            <span className="block font-medium">{slot.time}</span>
+            {caption ? (
+              <span className="block text-[11px] text-ink-muted">{caption}</span>
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/layout/StickyCtas.tsx
+++ b/components/layout/StickyCtas.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 import { hasUserConsented } from '@/lib/cookies'
 import { Utensils, Phone, MessageCircle } from 'lucide-react'
 import { Button } from '@/components/ui'
+import { QuickBookSheet } from '@/components/features/TableBooking/QuickBookSheet'
 import {
   trackTableBookingClick,
   trackMenuView,
@@ -55,6 +56,7 @@ export function StickyCtas() {
   const [visible, setVisible] = useState(false)
   const [cookieBannerVisible, setCookieBannerVisible] = useState(false)
   const [deviceType, setDeviceType] = useState<DeviceType>('unknown')
+  const [quickBookOpen, setQuickBookOpen] = useState(false)
 
   // The bar used to hide itself entirely while the cookie banner was up, because both are
   // pinned to the bottom of the viewport and would have overlapped. The cost of that was
@@ -181,19 +183,20 @@ export function StickyCtas() {
             Christmas enquiry
           </Button>
         ) : (
+          // Opens the quick-book sheet in place rather than navigating. The full form is
+          // still one tap away from inside the sheet, carrying whatever has been chosen,
+          // so nothing is lost for a booking that needs the longer questions.
           <Button
-            asChild
             variant="primary"
             size="md"
             className="flex-1 lg:flex-none"
             tabIndex={showStickyCtas ? undefined : -1}
+            onClick={() => {
+              trackTableBookingClick('sticky_global')
+              setQuickBookOpen(true)
+            }}
           >
-            <Link
-              href="/book-table"
-              onClick={() => trackTableBookingClick('sticky_global')}
-            >
-              Book a table
-            </Link>
+            Book a table
           </Button>
         )}
 
@@ -231,6 +234,12 @@ export function StickyCtas() {
           <MessageCircle className="h-5 w-5" aria-hidden />
         </a>
       </div>
+
+      <QuickBookSheet
+        open={quickBookOpen}
+        onClose={() => setQuickBookOpen(false)}
+        source="sticky_global"
+      />
     </div>
   )
 }

--- a/components/sunday-lunch/TimedBookingPrompt.tsx
+++ b/components/sunday-lunch/TimedBookingPrompt.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { LARGE_GROUP_DEPOSIT_POLICY_COPY } from '@/lib/constants'
 import {
   Modal,
   ModalBody,
@@ -117,8 +118,10 @@ export function TimedBookingPrompt({
             : `${sunday.availabilityLong} We are 7 minutes from Heathrow Terminal 5, and booking ahead is recommended for launch Sundays.`}
         </p>
         <p className="mt-3 text-sm text-ink-muted leading-relaxed">
-          Larger group? Parties of ten or more take a £10-per-person deposit
-          on booking, fully deducted from the bill on the day.
+          {/* Reads the shared constant rather than restating the rule. This paragraph
+              spelled the threshold as the word "ten", which is why it survived the
+              search that moved every other mention from 10 to 15. */}
+          Larger group? {LARGE_GROUP_DEPOSIT_POLICY_COPY}
         </p>
       </ModalBody>
       <ModalFooter>

--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -77,7 +77,7 @@ Effective from the **17 May 2026 walk-in launch**. Menu refreshed **29 April 202
 - **Walk-ins:** Welcome the whole window. Last seating is 5:30pm.
 - **Booking:** Strongly recommended for groups and peak slots, but not required.
 - **Max online party size:** 20. Larger groups must call.
-- **Deposit:** No Sunday-specific deposit. The standard large-group deposit (groups of 10+) applies on any day, any booking type, see §7.
+- **Deposit:** No Sunday-specific deposit. The standard large-group deposit (groups of 15+) applies on any day, any booking type, see §7.
 
 ### Current menu
 

--- a/lib/table-booking/__tests__/quick-book.test.ts
+++ b/lib/table-booking/__tests__/quick-book.test.ts
@@ -1,0 +1,240 @@
+import {
+  DEFAULT_PARTY_SIZE,
+  QUICK_BOOK_MAX_PARTY,
+  buildQuickBookPayload,
+  defaultQuickBookState,
+  findQuickBookRefusal,
+  fullFormHref,
+  quickDateChoices,
+  requiresFullForm,
+  resolveEmptyState,
+  resolveSubmitPurpose,
+  selectableSlots,
+} from '../quick-book'
+import type { AvailabilityData, AvailabilitySlot } from '../availability'
+
+function slot(overrides: Partial<AvailabilitySlot> = {}): AvailabilitySlot {
+  return {
+    time: '19:00',
+    available: true,
+    available_capacity: 8,
+    bookable_purpose: 'food_or_drinks',
+    ...overrides,
+  }
+}
+
+function availability(overrides: Partial<AvailabilityData> = {}): AvailabilityData {
+  return {
+    date: '2026-08-12',
+    available: true,
+    time_slots: [slot()],
+    calculation_state: 'complete',
+    ...overrides,
+  }
+}
+
+describe('the defaults are the common case, not a guess', () => {
+  it('defaults to a table for two', () => {
+    // 134 of 308 bookings in the 90 days to 2026-08-09 were for exactly two people.
+    expect(DEFAULT_PARTY_SIZE).toBe(2)
+    expect(defaultQuickBookState().partySize).toBe(2)
+  })
+
+  it('defaults to eating rather than drinks', () => {
+    // Failing safe. A food slot also seats a drinker; a drinks slot does not feed anyone,
+    // so defaulting the other way would quietly show times the kitchen cannot serve.
+    expect(defaultQuickBookState().purpose).toBe('food')
+  })
+
+  it('offers Today and Tomorrow as one-tap chips', () => {
+    const labels = quickDateChoices().map((c) => c.label)
+    expect(labels[0]).toBe('Today')
+    expect(labels[1]).toBe('Tomorrow')
+  })
+
+  it('adds Sunday when it is not already offered', () => {
+    const choices = quickDateChoices()
+    const labels = choices.map((c) => c.label)
+    const hasSunday = choices.some(
+      (c) => new Date(`${c.value}T00:00:00Z`).getUTCDay() === 0
+    )
+    // Sunday is the busiest booking day by a distance: 113 of 308 in 90 days, more than
+    // Friday and Saturday combined. It should never be more than one tap away.
+    expect(hasSunday).toBe(true)
+    expect(labels.length).toBeGreaterThanOrEqual(2)
+    expect(labels.length).toBeLessThanOrEqual(3)
+  })
+
+  it('never offers the same date twice', () => {
+    const values = quickDateChoices().map((c) => c.value)
+    expect(new Set(values).size).toBe(values.length)
+  })
+})
+
+describe('which slots a guest may tap', () => {
+  it('offers only food-capable slots when they want to eat', () => {
+    const data = availability({
+      time_slots: [
+        slot({ time: '12:00', bookable_purpose: 'food_or_drinks' }),
+        slot({ time: '21:00', bookable_purpose: 'drinks_only' }),
+      ],
+    })
+    expect(selectableSlots(data, 2, 'food').map((s) => s.time)).toEqual(['12:00'])
+  })
+
+  it('offers every slot when they only want a drink', () => {
+    const data = availability({
+      time_slots: [
+        slot({ time: '12:00', bookable_purpose: 'food_or_drinks' }),
+        slot({ time: '21:00', bookable_purpose: 'drinks_only' }),
+      ],
+    })
+    // A food-bookable table still seats somebody who only wants a pint.
+    expect(selectableSlots(data, 2, 'drinks')).toHaveLength(2)
+  })
+
+  it('hides slots too small for the party', () => {
+    const data = availability({ time_slots: [slot({ available_capacity: 3 })] })
+    expect(selectableSlots(data, 4, 'food')).toHaveLength(0)
+    expect(selectableSlots(data, 3, 'food')).toHaveLength(1)
+  })
+
+  it('shows nothing at all when the authoritative check never ran', () => {
+    // Locally guessed times presented as bookable is how a guest ends up holding a
+    // confirmation for a table that does not exist.
+    const data = availability({ calculation_state: 'unknown' })
+    expect(selectableSlots(data, 2, 'food')).toHaveLength(0)
+  })
+})
+
+describe('an empty grid explains itself', () => {
+  it('recovers a kitchen-closed day into a drinks booking', () => {
+    // The one that earns real money. On a Monday the kitchen is shut but the bar is open,
+    // and "no availability" sends away a guest who could have had a table.
+    const data = availability({
+      time_slots: [slot({ bookable_purpose: 'drinks_only' })],
+    })
+    expect(resolveEmptyState(data, 2, 'food', false)).toBe(
+      'kitchen_closed_but_drinks_available'
+    )
+  })
+
+  it('says nothing is free when drinks would not help either', () => {
+    const data = availability({ time_slots: [slot({ available_capacity: 1 })] })
+    expect(resolveEmptyState(data, 6, 'food', false)).toBe('nothing_today')
+  })
+
+  it('distinguishes a failed check from a full day', () => {
+    const data = availability({ calculation_state: 'unknown' })
+    expect(resolveEmptyState(data, 2, 'food', false)).toBe('check_failed')
+  })
+
+  it('reports nothing when there are times to show', () => {
+    expect(resolveEmptyState(availability(), 2, 'food', false)).toBe('none')
+  })
+
+  it('stays in loading while the request is in flight', () => {
+    expect(resolveEmptyState(null, 2, 'food', true)).toBe('loading')
+  })
+})
+
+describe('the slot narrows the purpose, not the guest', () => {
+  it('submits drinks against a drinks-only slot even when they asked to eat', () => {
+    // On a day where the food check failed the whole grid is drinks_only. Submitting
+    // 'food' is rejected by the service-window check with an error nobody can act on.
+    expect(resolveSubmitPurpose('drinks_only', 'food')).toBe('drinks')
+  })
+
+  it('respects the guest on a slot that permits both', () => {
+    expect(resolveSubmitPurpose('food_or_drinks', 'food')).toBe('food')
+    expect(resolveSubmitPurpose('food_or_drinks', 'drinks')).toBe('drinks')
+  })
+})
+
+describe('handing over to the full form', () => {
+  it('hands over above the quick-book party cap', () => {
+    expect(requiresFullForm(QUICK_BOOK_MAX_PARTY)).toBe(false)
+    expect(requiresFullForm(QUICK_BOOK_MAX_PARTY + 1)).toBe(true)
+  })
+
+  it('carries the choices already made', () => {
+    const href = fullFormHref({ partySize: 4, date: '2026-08-12', time: '19:00' })
+    expect(href).toContain('party_size=4')
+    expect(href).toContain('date=2026-08-12')
+    expect(href).toContain('time=19%3A00')
+  })
+
+  it('sends only params the booking page actually reads', () => {
+    // app/book-table/page.tsx reads date, time and party_size. Sending `purpose` would
+    // look like it carried the food choice over and silently would not, so the guest
+    // re-answers a question they believe they have answered.
+    const href = fullFormHref({ partySize: 2, date: '2026-08-12', purpose: 'drinks' })
+    expect(href).not.toContain('purpose')
+  })
+
+  it('falls back to a bare link with nothing chosen', () => {
+    expect(fullFormHref({})).toBe('/book-table')
+  })
+})
+
+describe('validation reports fields in the order they were filled in', () => {
+  const base = { time: '19:00', phone: '07700900000', firstName: 'Jane' }
+
+  it('accepts a complete booking', () => {
+    expect(findQuickBookRefusal(base)).toBeNull()
+  })
+
+  it('asks for a time before anything else', () => {
+    expect(findQuickBookRefusal({ ...base, time: null, phone: '', firstName: '' })?.field).toBe(
+      'time'
+    )
+  })
+
+  it('asks for the phone before the name', () => {
+    // Reporting the last field first makes a form feel like it is arguing back.
+    expect(findQuickBookRefusal({ ...base, phone: '', firstName: '' })?.field).toBe('phone')
+  })
+
+  it('catches an obviously incomplete number', () => {
+    expect(findQuickBookRefusal({ ...base, phone: '0770' })?.field).toBe('phone')
+  })
+
+  it('accepts the shapes real guests type', () => {
+    for (const phone of ['07700 900000', '+44 7700 900000', '(07700) 900000']) {
+      expect(findQuickBookRefusal({ ...base, phone })).toBeNull()
+    }
+  })
+})
+
+describe('the submitted payload', () => {
+  it('carries every field the create endpoint requires', () => {
+    const payload = buildQuickBookPayload({
+      state: { partySize: 4, date: '2026-08-12', purpose: 'food' },
+      time: '19:00',
+      slotPurpose: 'food_or_drinks',
+      phone: '  07700 900000 ',
+      firstName: '  Jane ',
+    })
+
+    // The route rejects with 'Missing required fields' without all five.
+    expect(payload).toMatchObject({
+      phone: '07700 900000',
+      date: '2026-08-12',
+      time: '19:00',
+      party_size: 4,
+      purpose: 'food',
+      first_name: 'Jane',
+    })
+  })
+
+  it('downgrades purpose when the slot only permits drinks', () => {
+    const payload = buildQuickBookPayload({
+      state: { partySize: 2, date: '2026-08-12', purpose: 'food' },
+      time: '21:00',
+      slotPurpose: 'drinks_only',
+      phone: '07700900000',
+      firstName: 'Jane',
+    })
+    expect(payload.purpose).toBe('drinks')
+  })
+})

--- a/lib/table-booking/quick-book.ts
+++ b/lib/table-booking/quick-book.ts
@@ -1,0 +1,245 @@
+import { londonNowParts } from '@/lib/table-booking-service-windows'
+import type { AvailabilityData, AvailabilitySlot } from './availability'
+
+/**
+ * The quick-book sheet: the shortest honest path from "I want a table" to a confirmed
+ * booking, without a page load.
+ *
+ * The pure logic lives here rather than in the component so the decisions that actually
+ * matter, which defaults are chosen and when the sheet must hand over to the full form,
+ * can be tested without rendering anything.
+ *
+ * The design principle throughout: the fastest journey is not the one with the fewest
+ * screens, it is the one with the fewest DECISIONS. Every default below is chosen because
+ * the live booking data says it is what most people would have picked anyway, so the
+ * common case is "tap a time, type a number, done".
+ */
+
+/** Live data, 90 days to 2026-08-09: 134 of 308 bookings were for exactly two people. */
+export const DEFAULT_PARTY_SIZE = 2
+
+/**
+ * The largest party the sheet will take. Above this the guest needs the full form, which
+ * asks about high chairs, accessible tables and outside seating, and above 15 a deposit is
+ * due. Quietly booking a party of 16 with none of those questions asked would produce a
+ * booking the pub cannot actually seat.
+ */
+export const QUICK_BOOK_MAX_PARTY = 8
+
+export type QuickBookPurpose = 'food' | 'drinks'
+
+export type QuickBookState = {
+  partySize: number
+  /** ISO yyyy-mm-dd, always resolved in Europe/London rather than the device's zone. */
+  date: string
+  purpose: QuickBookPurpose
+}
+
+export function defaultQuickBookState(): QuickBookState {
+  return {
+    partySize: DEFAULT_PARTY_SIZE,
+    date: londonNowParts().isoDate,
+    // Food, not drinks. A guest who wants drinks can still sit at a food-bookable slot,
+    // but the reverse is not true, so defaulting to drinks would silently show times the
+    // kitchen cannot serve and send people to a table with no food. Defaulting to food
+    // fails safe: the worst case is a slightly shorter list of times.
+    purpose: 'food',
+  }
+}
+
+/** yyyy-mm-dd for "today + n" in Europe/London, without importing a date library. */
+export function londonDatePlusDays(days: number): string {
+  const today = londonNowParts().isoDate
+  const [y, m, d] = today.split('-').map(Number)
+  // Constructed as UTC midnight purely as calendar arithmetic. It is never rendered as a
+  // time, so the offset cannot shift the day the way `new Date(iso)` in local time would.
+  const shifted = new Date(Date.UTC(y, m - 1, d + days))
+  return shifted.toISOString().slice(0, 10)
+}
+
+export type DateChoice = { value: string; label: string }
+
+/**
+ * The three dates offered as one-tap chips. Sunday is included when it is not already
+ * Today or Tomorrow because it is the single busiest booking day: 113 of 308 bookings in
+ * the last 90 days, more than Friday and Saturday combined.
+ */
+export function quickDateChoices(): DateChoice[] {
+  const today = londonDatePlusDays(0)
+  const tomorrow = londonDatePlusDays(1)
+  const choices: DateChoice[] = [
+    { value: today, label: 'Today' },
+    { value: tomorrow, label: 'Tomorrow' },
+  ]
+
+  for (let ahead = 2; ahead <= 7; ahead += 1) {
+    const candidate = londonDatePlusDays(ahead)
+    if (new Date(`${candidate}T00:00:00Z`).getUTCDay() === 0) {
+      choices.push({ value: candidate, label: 'Sunday' })
+      break
+    }
+  }
+
+  return choices
+}
+
+/**
+ * Slots a guest may actually tap.
+ *
+ * `bookable_purpose` is authoritative, never `kitchen_open`, which is the published
+ * window and says nothing about whether a table can be booked to eat at.
+ */
+export function selectableSlots(
+  availability: AvailabilityData | null,
+  partySize: number,
+  purpose: QuickBookPurpose
+): AvailabilitySlot[] {
+  if (!availability) return []
+  // 'unknown' means the authoritative check never ran. Showing locally guessed times as
+  // bookable is how a guest ends up with a confirmation for a table that does not exist.
+  if (availability.calculation_state === 'unknown') return []
+
+  return availability.time_slots.filter((slot) => {
+    if (slot.available === false) return false
+    if (slot.available_capacity < partySize) return false
+    // 'drinks_only' still seats a guest who only wants a drink, so a drinks request
+    // accepts both values. A food request accepts only 'food_or_drinks'.
+    if (purpose === 'food') return slot.bookable_purpose === 'food_or_drinks'
+    return true
+  })
+}
+
+/**
+ * What to submit as `purpose` for a slot, which is not simply what the guest tapped.
+ *
+ * The slot is the authority. On a day where the food check failed the whole grid comes
+ * back 'drinks_only', and submitting 'food' against it is rejected by the service-window
+ * check with an error the guest can do nothing about. Narrowing to what the slot actually
+ * permits turns that dead end into a booking.
+ */
+export function resolveSubmitPurpose(
+  slotPurpose: AvailabilitySlot['bookable_purpose'],
+  requested: QuickBookPurpose
+): QuickBookPurpose {
+  if (slotPurpose === 'drinks_only') return 'drinks'
+  return requested
+}
+
+export type EmptyStateReason =
+  | 'loading'
+  | 'kitchen_closed_but_drinks_available'
+  | 'nothing_today'
+  | 'check_failed'
+  | 'none'
+
+/**
+ * Why the grid is empty, so the sheet can say something useful instead of "no times".
+ *
+ * The distinction that earns its keep is kitchen-closed versus nothing-free. On a Monday
+ * the kitchen is shut but the bar is open, and a guest told "no availability" walks away
+ * from a table they could have had. That is a one-tap recovery, not a dead end.
+ */
+export function resolveEmptyState(
+  availability: AvailabilityData | null,
+  partySize: number,
+  purpose: QuickBookPurpose,
+  isLoading: boolean
+): EmptyStateReason {
+  if (isLoading) return 'loading'
+  if (!availability) return 'loading'
+  if (availability.calculation_state === 'unknown') return 'check_failed'
+  if (selectableSlots(availability, partySize, purpose).length > 0) return 'none'
+
+  if (purpose === 'food') {
+    const drinksInstead = selectableSlots(availability, partySize, 'drinks')
+    if (drinksInstead.length > 0) return 'kitchen_closed_but_drinks_available'
+  }
+
+  return 'nothing_today'
+}
+
+/**
+ * Whether this booking must go to the full form instead.
+ *
+ * Kept as one function so there is a single place that answers it, and so the sheet can
+ * hand over BEFORE the guest has typed anything rather than failing at submit.
+ */
+export function requiresFullForm(partySize: number): boolean {
+  return partySize > QUICK_BOOK_MAX_PARTY
+}
+
+/**
+ * Deep link into the full booking form carrying whatever the guest already chose, so
+ * handing over never costs them the taps they have already spent.
+ *
+ * Only date, time and party_size are sent, because those are the only three
+ * `app/book-table/page.tsx` reads. Adding `purpose` here would look like it carried the
+ * food-or-drinks choice over and silently would not, which is worse than not sending it:
+ * the guest re-answers a question they think they have already answered.
+ */
+export function fullFormHref(state: Partial<QuickBookState> & { time?: string | null }): string {
+  const params = new URLSearchParams()
+  if (state.partySize) params.set('party_size', String(state.partySize))
+  if (state.date) params.set('date', state.date)
+  if (state.time) params.set('time', state.time)
+  const query = params.toString()
+  return query ? `/book-table?${query}` : '/book-table'
+}
+
+export type QuickBookSubmission = {
+  state: QuickBookState
+  time: string
+  /** The slot's authoritative purpose, captured at tap time. */
+  slotPurpose: AvailabilitySlot['bookable_purpose']
+  phone: string
+  firstName: string
+}
+
+export type QuickBookRefusal = { field: 'phone' | 'firstName' | 'time'; message: string }
+
+/**
+ * Validation, in the order the guest filled the fields in. Reporting the last field first
+ * makes a form feel like it is arguing back.
+ */
+export function findQuickBookRefusal(input: {
+  time: string | null
+  phone: string
+  firstName: string
+}): QuickBookRefusal | null {
+  if (!input.time) {
+    return { field: 'time', message: 'Please choose a time.' }
+  }
+
+  const phone = input.phone.trim()
+  if (!phone) {
+    return { field: 'phone', message: 'Please enter your mobile number.' }
+  }
+  // Loose on purpose. The management API normalises to E.164 and is the authority; this
+  // only catches an obviously incomplete number before a round trip. UK mobiles are 11
+  // digits, +44 forms are 12, and we accept anything in that region rather than trying to
+  // out-parse libphonenumber in the browser.
+  const digits = phone.replace(/\D/g, '')
+  if (digits.length < 10) {
+    return { field: 'phone', message: 'That mobile number looks too short. Please check it.' }
+  }
+
+  if (!input.firstName.trim()) {
+    return { field: 'firstName', message: 'Please enter your first name.' }
+  }
+
+  return null
+}
+
+export function buildQuickBookPayload(submission: QuickBookSubmission) {
+  return {
+    phone: submission.phone.trim(),
+    date: submission.state.date,
+    time: submission.time,
+    party_size: submission.state.partySize,
+    // Narrowed by the SLOT, not taken from the chip the guest tapped. See
+    // resolveSubmitPurpose for why that difference matters.
+    purpose: resolveSubmitPurpose(submission.slotPurpose, submission.state.purpose),
+    first_name: submission.firstName.trim(),
+    default_country_code: 'GB',
+  }
+}

--- a/tests/unit/deposit-threshold-consistency.test.ts
+++ b/tests/unit/deposit-threshold-consistency.test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs'
+import path from 'path'
+import { LARGE_GROUP_DEPOSIT_THRESHOLD } from '@/lib/constants'
+
+/**
+ * The threshold moved from 10 to 15 on 2026-08-09, and seven customer-facing sentences
+ * were missed because they spelled it as the word "ten" rather than the digit. One page
+ * ended up with two adjacent bullets contradicting each other: "No deposits for groups
+ * under 15" directly above "Groups of 10+: £10 per person deposit".
+ *
+ * A stale deposit promise is not cosmetic. It is a price the guest was quoted, and the
+ * till charges something else.
+ *
+ * This scans the customer-facing tree for every way the OLD rule can be written. It is
+ * deliberately about the deposit specifically: "groups of 10 to 150" is a room capacity,
+ * "10 or more, give us a heads up" is about pre-ordering a round, and neither is a price.
+ */
+
+const ROOTS = ['app', 'components', 'lib']
+const EXTENSIONS = new Set(['.ts', '.tsx'])
+
+function walk(dir: string, found: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walk(full, found)
+    } else if (EXTENSIONS.has(path.extname(entry.name)) && !full.includes('__tests__')) {
+      found.push(full)
+    }
+  }
+  return found
+}
+
+/**
+ * Ways a deposit threshold of ten has been written in this repo. Each requires a deposit
+ * word nearby, so capacity and pre-order sentences do not trip it.
+ */
+const STALE_PATTERNS: { label: string; pattern: RegExp }[] = [
+  { label: 'the word "ten"', pattern: /(groups?|parties|party) of ten or more[^.]{0,80}deposit/i },
+  { label: '"ten or more ... £10 per person"', pattern: /ten or more[^.]{0,60}£10 per person/i },
+  { label: '"10+" beside a deposit', pattern: /(groups?|parties) of 10\+[^.]{0,60}deposit/i },
+  { label: '"Groups of 10+: ... deposit"', pattern: /groups? of 10\+\s*:[^.]{0,60}deposit/i },
+  { label: '"10 or more" beside a deposit', pattern: /(groups?|parties) of 10 or more[^.]{0,60}deposit/i },
+]
+
+describe('no page still quotes the old deposit threshold', () => {
+  const files = ROOTS.flatMap((root) => walk(path.join(process.cwd(), root)))
+
+  it('scans a meaningful number of files', () => {
+    // Guards the guard: a walk that silently found nothing would pass everything below.
+    expect(files.length).toBeGreaterThan(100)
+  })
+
+  it.each(STALE_PATTERNS)('finds no customer-facing $label', ({ pattern }) => {
+    const offenders = files.filter((file) => pattern.test(fs.readFileSync(file, 'utf8')))
+    expect(offenders.map((f) => path.relative(process.cwd(), f))).toEqual([])
+  })
+
+  it('keeps the shared policy copy in step with the constant', () => {
+    const constants = fs.readFileSync(path.join(process.cwd(), 'lib/constants.ts'), 'utf8')
+    const copy = /LARGE_GROUP_DEPOSIT_POLICY_COPY =\s*\n?\s*"([^"]+)"/.exec(constants)?.[1]
+    expect(copy).toBeDefined()
+    expect(copy).toContain(`${LARGE_GROUP_DEPOSIT_THRESHOLD} or more`)
+  })
+
+  it('keeps the SSOT free of a contradicting threshold', () => {
+    const ssot = fs.readFileSync(path.join(process.cwd(), 'docs/SSOT.md'), 'utf8')
+    // The changelog note legitimately mentions the old number while explaining the
+    // change, so only rule statements are checked.
+    const ruleStatements = ssot.match(/groups? of \d+\+?[^.\n]{0,60}(deposit|applies)/gi) || []
+    const stale = ruleStatements.filter((line) => !line.includes(String(LARGE_GROUP_DEPOSIT_THRESHOLD)))
+    expect(stale).toEqual([])
+  })
+})


### PR DESCRIPTION
The sticky **Book a table** button now opens a sheet in place instead of loading `/book-table`. For the ordinary booking the journey is: tap Book, tap a time, type a phone number and first name, tap Book table.

## Why not just use the wizard
The full wizard asks the right questions for a *complicated* booking: high chairs, accessible tables, outside seating, deposits, seasonal menus. For a table for two tonight, all of that sits between a guest and a booking they had already decided to make.

The sheet does not reimplement it, it short-circuits it. Availability, slot purpose and the create payload all come from **the same modules the wizard uses**, so the two cannot drift into disagreeing about what is bookable. Above eight people, or when high chairs or outside seating might matter, it links to the full form carrying date, time and party size so no taps are lost.

## Defaults come from the live data, not a guess
Two people (134 of 308 bookings in 90 days), today, eating. Sunday appears as a one-tap chip because it is the busiest day by a distance: 113 of 308, more than Friday and Saturday combined.

Eating is the safe default: **a food slot also seats a drinker, and the reverse is not true**, so defaulting the other way would quietly show times the kitchen cannot serve.

## The recovery that earns its keep
On a Monday the kitchen is shut but the bar is open. "No availability" sends away a guest who could have had a table. A food request with no food slots but free drinks slots now offers a one-tap switch instead of a dead end. This is not hypothetical: it is what today looks like, and it is what I tested against.

## Purpose is narrowed by the slot, not the chip
On a day where the food check failed, the whole grid comes back `drinks_only`. Submitting `'food'` against it is rejected by the service-window check with an error the guest can do nothing about.

## Also fixes a miss from the threshold change
Seven customer-facing sentences still promised the deposit at **10** guests, because they spelled it as the word "ten" and escaped my earlier search. Worst case, the world-cup page:

> No deposits for groups under 15
> Groups of 10+: £10 per person deposit

Two adjacent bullets contradicting each other, one of them my own fix. `docs/SSOT.md` contradicted itself the same way, in the canonical file everything else is supposed to follow.

A stale deposit line is a price the guest was quoted and the till does not charge, so there is now a guard test scanning for every spelling of the old rule. **I confirmed it fails when one is reintroduced** rather than trusting a green tick.

## Testing done
- [x] 1,433 tests pass, 35 new. Lint clean, `tsc --noEmit` clean, production build passes.
- [x] Drove the whole flow in a 375px viewport: Monday's closed kitchen detected, drinks recovery switched the grid, 16:00 selected, summary and consent notice correct, both validation refusals fired, full-form link carried `party_size=2&date=2026-08-10&time=16:00`.

**Deliberately did not submit a booking**, since that would create a real one in the live database. The submit path is covered by unit tests over the payload builder and validation.

## Complexity score
M

## Breaking changes
None. `/book-table` is unchanged and still reachable from inside the sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)