### PR TITLE
fix(book-table): stop a cold management API reading as "we could not check"

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1158,20 +1158,30 @@ export class AnchorAPI {
     } as RequestInit & { next: { revalidate: number } })
   }
 
-  // Load read-out with a bounded wait: 3 seconds per attempt, one retry, then
-  // null. A null result means availability is UNKNOWN, never "assume free".
-  // Callers must not present locally guessed slots as bookable on the back of
-  // a null here; the availability route answers `calculation_state: 'unknown'`
-  // instead (review F04).
+  // Load read-out with a bounded wait, then null. A null result means
+  // availability is UNKNOWN, never "assume free". Callers must not present
+  // locally guessed slots as bookable on the back of a null here; the
+  // availability route answers `calculation_state: 'unknown'` instead
+  // (review F04).
+  //
+  // The retry deliberately waits longer and backs off first. Both attempts used
+  // to be 3 seconds fired back to back, which covered a slow response but NOT a
+  // cold start: when the management API redeploys, its first request pays the
+  // serverless boot plus several database round trips, comfortably past 3
+  // seconds, and the retry landed inside the same cold window. Every guest on
+  // the booking page during a deploy was told we could not check availability,
+  // on an API that was working. Warm, this call measures around 1.2 seconds, so
+  // the first attempt still fails fast when something is genuinely wrong.
   async getTableBookingLoadSafe(
     date: string,
     availability?: TableAvailabilityQuery,
     timeoutMs = 3000
   ): Promise<TableBookingLoadResponse | null> {
-    const maxAttempts = 2
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const attemptTimeouts = [timeoutMs, Math.max(timeoutMs, 6000)]
+
+    for (let attempt = 1; attempt <= attemptTimeouts.length; attempt++) {
       const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), timeoutMs)
+      const timeout = setTimeout(() => controller.abort(), attemptTimeouts[attempt - 1])
 
       try {
         return await this.getTableBookingLoad(date, { signal: controller.signal }, availability)
@@ -1179,10 +1189,17 @@ export class AnchorAPI {
         console.warn('[table-bookings] Booking load attempt failed', {
           date,
           attempt,
+          timeoutMs: attemptTimeouts[attempt - 1],
           error: error instanceof Error ? error.message : String((error as any)?.message || error),
         })
       } finally {
         clearTimeout(timeout)
+      }
+
+      // Give a cold instance a moment to finish booting before asking again.
+      // Retrying immediately just burns the second attempt on the same boot.
+      if (attempt < attemptTimeouts.length) {
+        await new Promise((resolve) => setTimeout(resolve, 500))
       }
     }
 


### PR DESCRIPTION
## The incident

The booking page showed **"We could not check live availability"** a few minutes after the management API deployed, on an API that was working correctly.

Verified during the incident:
- `check_table_availability_v06` returned **23 available slots** for the exact options on screen (2 guests, step-free table, 1 high chair, 11 Aug 2026)
- Every management API endpoint answered **HTTP 200**
- The live site endpoint answered `calculation_state: complete` with 12 slots once things settled

So nothing was actually broken. The page was reporting a failure that had not happened.

## Cause

`getTableBookingLoadSafe` allowed 3 seconds per attempt and fired both attempts back to back. That covers a slow response, but not a cold start: when the management API redeploys, its first request pays the serverless boot plus several database round trips, comfortably past 3 seconds, and the retry landed inside the same cold window.

Every guest on the booking page during a deploy was told availability could not be checked.

## Fix

The retry now waits 500ms and allows 6 seconds. Warm, this call measures about **1.2 seconds**, so the first attempt still fails fast when something is genuinely wrong, and the page still fails closed rather than guessing at availability.

## Testing

132 suites, 1,460 tests pass. Clean TypeScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)