### PR TITLE
fix(events): stop the booking CTA column collapsing on wide event cards

### DIFF
--- a/app/cash-bingo/page.tsx
+++ b/app/cash-bingo/page.tsx
@@ -227,8 +227,8 @@ function BingoEventCards({ events }: { events: Event[] }) {
 	                </p>
               </div>
 
-              <div className="w-full lg:w-64 space-y-3">
-                <EventBookingButton event={event} className="w-full" source="cash_bingo_event_card" />
+              <div className="w-full space-y-3 lg:w-64 lg:shrink-0">
+                <EventBookingButton event={event} className="w-full lg:px-6" source="cash_bingo_event_card" />
               </div>
             </CardBody>
           </Card>

--- a/app/music-bingo/page.tsx
+++ b/app/music-bingo/page.tsx
@@ -259,8 +259,8 @@ function MusicBingoEventCards({ events }: { events: Event[] }) {
                 </p>
               </div>
 
-              <div className="w-full space-y-3 lg:w-64">
-                <EventBookingButton event={event} className="w-full" source="music_bingo_event_card" />
+              <div className="w-full space-y-3 lg:w-64 lg:shrink-0">
+                <EventBookingButton event={event} className="w-full lg:px-6" source="music_bingo_event_card" />
               </div>
             </CardBody>
           </Card>

--- a/app/quiz-night/page.tsx
+++ b/app/quiz-night/page.tsx
@@ -250,8 +250,8 @@ function QuizNightEvents({ events }: { events: Event[] }) {
 	                </p>
               </div>
 
-              <div className="w-full lg:w-64 space-y-3">
-                <EventBookingButton event={event} className="w-full" source="quiz_night_event_card" />
+              <div className="w-full space-y-3 lg:w-64 lg:shrink-0">
+                <EventBookingButton event={event} className="w-full lg:px-6" source="quiz_night_event_card" />
               </div>
             </CardBody>
           </Card>


### PR DESCRIPTION
## What changed

The booking button column on the cash bingo, music bingo and quiz night event cards was `w-full lg:w-64` inside a flex row. Without `shrink-0`, flex was free to squeeze it below 64 when the copy beside it ran long, so the button width wandered from card to card. Pinning it and giving the button `lg:px-6` keeps the column a fixed 16rem on desktop with the label comfortably inside it.

Also normalises the class order on cash-bingo and quiz-night to match music-bingo, which already had it right.

## Why

This was the owner's own work, sitting uncommitted in the working tree since before the seasonal build. It existed on no branch, so a working-tree reset would have lost it.

Committed on top of the current `main` rather than on `fix/event-page-card-layout`, because that branch predates today's width and seasonal changes and these files have moved since.

## Testing done

- [x] Automated tests: 1595 pass, typecheck clean, lint clean including the page-width audit.
- [ ] Manual testing: not done. Three CSS classes on desktop card layout, worth an eyeball on a wide screen before merge.

## Complexity score

XS. Three lines.

## Breaking changes

None.

## Migration risk

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)