### PR TITLE
refactor(events): share one upcoming-dates list across the four event pages

### DIFF
--- a/app/cash-bingo/page.tsx
+++ b/app/cash-bingo/page.tsx
@@ -1,8 +1,5 @@
-import Image from 'next/image'
-import { getEventHeroImage } from '@/lib/event-image'
 import { Metadata } from 'next'
 import {
-  Badge,
   Button,
   Container,
   Card,
@@ -20,16 +17,16 @@ import { CONTACT } from '@/lib/constants'
 import { FAQAccordionWithSchema } from '@/components/FAQAccordionWithSchema'
 import { EventSchema } from '@/components/seo/EventSchema'
 import { EventBookingButton } from '@/components/EventBookingButton'
+import { EventDateCards } from '@/components/features/EventDateCards'
 import {
   getEventCategories,
   getUpcomingEventsByCategory,
   formatEventDate,
   formatEventTime,
-  formatDoorTime,
+  formatDoorClockTime,
   type Event,
   type EventCategory
 } from '@/lib/api'
-import { getEventWebsiteUrl } from '@/lib/event-url'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { BookTableButton } from '@/components/BookTableButton'
@@ -158,83 +155,29 @@ const FAQS = [
 ]
 
 function BingoEventCards({ events }: { events: Event[] }) {
-  if (!events.length) {
-    return (
-      <Card accent>
-      <CardBody className="text-center">
-        <p className="text-lg font-semibold text-accent-text mb-2">New cash bingo dates are loading soon</p>
-        <p className="text-ink-muted">
-          We’re finalising the next jackpot night. Call 01753 682707 and we’ll text you as soon as books go on sale.
-        </p>
-      </CardBody>
-      </Card>
-    )
-  }
-
   return (
-    <div className="space-y-6">
-      {events.map((event, index) => {
-        const doorTime = formatDoorTime(event.doorTime)
-        const startTime = formatEventTime(event.startDate)
-        const isDraft = (event.eventStatus || '').toLowerCase().includes('draft')
-        const isScheduled = (event.eventStatus || '').toLowerCase().includes('scheduled')
-        const isTentative = isDraft || (!isScheduled && new Date(event.startDate).getTime() > new Date().getTime() + 30 * 24 * 60 * 60 * 1000)
-        const eventUrl = getEventWebsiteUrl(event)
-        const imageSrc = getEventHeroImage(event)
-
-        return (
-          <Card key={event.id} hover accent className="overflow-hidden">
-            <div className="border-b border-line bg-surface-sunk px-5 py-4 flex flex-wrap items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <p className="text-xs uppercase tracking-wide text-ink-muted">Monthly cash bingo</p>
-                  {isTentative && (
-                    <Badge variant="outline">Tentative</Badge>
-                  )}
-                </div>
-                <Link href={eventUrl} className="block text-xl font-semibold text-ink-strong hover:text-accent-text transition">
-                  {event.name}
-                </Link>
-                <p className="text-sm text-ink-muted line-clamp-1">{formatEventDate(event.startDate)}</p>
-              </div>
-	              <div className="text-right">
-	                <p className="text-lg font-semibold text-ink-strong">{startTime}</p>
-	                <p className="text-xs text-ink-muted">Doors {doorTime ?? '6:00pm'} • £10 cash book</p>
-	              </div>
-            </div>
-            <CardBody className="flex flex-col gap-6 lg:flex-row lg:items-stretch lg:gap-8">
-              {imageSrc && (
-                <Link href={eventUrl} className="w-full lg:w-48">
-                  <div className="relative aspect-square rounded-xl overflow-hidden shadow-sm">
-                    <Image
-                      src={imageSrc}
-                      alt={`${event.name} cash bingo night at The Anchor`}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 1024px) 100vw, 192px"
-                      loading={index < 2 ? 'eager' : 'lazy'}
-                    />
-                  </div>
-                </Link>
-              )}
-
-              <div className="flex-1 space-y-4">
-                {event.description && (
-                  <p className="text-ink-muted leading-relaxed">{event.description}</p>
-                )}
-	                <p className="text-sm text-ink-muted">
-	                  £10 cash-only books cover all ten games. The jackpot pot grows with every ticket sold, and the snowball bonus increases by £20, and two extra calls, each time it rolls over. Stay loyal, sign the Snowball Register and the prize gets easier to win.
-	                </p>
-              </div>
-
-              <div className="w-full space-y-3 lg:w-64 lg:shrink-0">
-                <EventBookingButton event={event} className="w-full lg:px-6" source="cash_bingo_event_card" />
-              </div>
-            </CardBody>
-          </Card>
-        )
-      })}
-    </div>
+    <EventDateCards
+      events={events}
+      eyebrow="Monthly cash bingo"
+      bookingSource="cash_bingo_event_card"
+      imageAltSuffix="cash bingo night at The Anchor"
+      renderMeta={(_event, doorTime) => (
+        <p className="text-xs text-ink-muted">Doors {doorTime ?? '6:00pm'} • £10 cash book</p>
+      )}
+      renderDetails={() => (
+        <p className="text-sm text-ink-muted">
+          £10 cash-only books cover all ten games. The jackpot pot grows with every ticket sold, and the snowball bonus increases by £20, and two extra calls, each time it rolls over. Stay loyal, sign the Snowball Register and the prize gets easier to win.
+        </p>
+      )}
+      emptyState={
+        <>
+          <p className="text-lg font-semibold text-accent-text mb-2">New cash bingo dates are loading soon</p>
+          <p className="text-ink-muted">
+            We’re finalising the next jackpot night. Call 01753 682707 and we’ll text you as soon as books go on sale.
+          </p>
+        </>
+      }
+    />
   )
 }
 
@@ -243,7 +186,7 @@ export default async function CashBingoPage() {
   const nextEvent = events[0]
   const nextEventDate = nextEvent ? formatEventDate(nextEvent.startDate) : 'Next date to be confirmed'
   const nextEventTime = nextEvent ? formatEventTime(nextEvent.startDate) : '7:00 pm start'
-  const doorTime = nextEvent ? formatDoorTime(nextEvent.doorTime) ?? '6:00 pm' : '6:00 pm'
+  const doorTime = nextEvent ? formatDoorClockTime(nextEvent.doorTime) ?? '6:00 pm' : '6:00 pm'
 
 	  const heroDescription = nextEvent
 	    ? `Doors ${doorTime}. Bingo starts at ${nextEventTime} with £10 cash-only bingo tickets (books). Reserve online or call 01753 682707 to lock in your table.`

--- a/app/karaoke/page.tsx
+++ b/app/karaoke/page.tsx
@@ -1,9 +1,6 @@
 
-import Image from 'next/image'
-import { getEventHeroImage } from '@/lib/event-image'
 import { Metadata } from 'next'
 import {
-    Badge,
     Button,
     Container,
     Card,
@@ -21,16 +18,15 @@ import { HeroBadge } from '@/components/HeroBadge'
 import { FAQAccordionWithSchema } from '@/components/FAQAccordionWithSchema'
 import { EventSchema } from '@/components/seo/EventSchema'
 import { EventBookingButton } from '@/components/EventBookingButton'
+import { EventDateCards } from '@/components/features/EventDateCards'
 import {
     getEventCategories,
     getUpcomingEventsByCategory,
     formatEventDate,
     formatEventTime,
-    formatDoorTime,
     type Event,
     type EventCategory
 } from '@/lib/api'
-import { getEventWebsiteUrl } from '@/lib/event-url'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { BookTableButton } from '@/components/BookTableButton'
@@ -163,80 +159,27 @@ const FAQS = [
 ]
 
 function KaraokeEventCards({ events }: { events: Event[] }) {
-    if (!events.length) {
-        return (
-            <Card accent><CardBody className="text-center">
-                <p className="text-lg font-semibold text-accent-text mb-2">Next karaoke dates coming soon</p>
-                <p className="text-ink-muted">
-                    We're tuning the mics and scheduling the next night. Call 01753 682707 or check back shortly.
-                </p>
-            </CardBody></Card>
-        )
-    }
-
     return (
-        <div className="space-y-6">
-            {events.map((event, index) => {
-                const doorTime = formatDoorTime(event.doorTime)
-                const startTime = formatEventTime(event.startDate)
-                const isTentative = new Date(event.startDate).getTime() > new Date().getTime() + 30 * 24 * 60 * 60 * 1000 || (event.eventStatus || '').toLowerCase().includes('draft')
-                const eventUrl = getEventWebsiteUrl(event)
-                const imageSrc = getEventHeroImage(event)
-
-                return (
-                    <Card key={event.id} hover accent className="overflow-hidden">
-                        <div className="border-b border-line bg-surface-sunk px-5 py-4 flex flex-wrap items-center justify-between gap-3">
-                            <div className="min-w-0">
-                                <div className="flex items-center gap-2 mb-1">
-                                    <p className="text-xs uppercase tracking-wide text-ink-muted">Karaoke Night</p>
-                                    {isTentative && (
-                                        <Badge variant="outline">Tentative</Badge>
-                                    )}
-                                </div>
-                                <Link href={eventUrl} className="block text-xl font-semibold text-ink-strong hover:text-accent-text transition">
-                                    {event.name}
-                                </Link>
-                                <p className="text-sm text-ink-muted line-clamp-1">{formatEventDate(event.startDate)}</p>
-                            </div>
-                            <div className="text-right">
-                                <p className="text-lg font-semibold text-ink-strong">{startTime}</p>
-                                <p className="text-xs text-ink-muted">Free Entry</p>
-                            </div>
-                        </div>
-
-                        <CardBody className="flex flex-col gap-6 lg:flex-row lg:items-stretch lg:gap-8">
-                            {imageSrc && (
-                                <Link href={eventUrl} className="w-full lg:w-48">
-                                    <div className="relative aspect-square rounded-xl overflow-hidden shadow-sm">
-                                        <Image
-                                            src={imageSrc}
-                                            alt={`${event.name} at The Anchor`}
-                                            fill
-                                            className="object-cover"
-                                            sizes="(max-width: 1024px) 100vw, 192px"
-                                            loading={index < 2 ? 'eager' : 'lazy'}
-                                        />
-                                    </div>
-                                </Link>
-                            )}
-
-                            <div className="flex-1 space-y-4">
-                                {event.description && (
-                                    <p className="text-ink-muted leading-relaxed">{event.description}</p>
-                                )}
-                                <p className="text-sm text-ink-muted">
-                                    Grab the mic and show us what you've got. Check the event listing for host, timings and song details.
-                                </p>
-                            </div>
-
-                            <div className="w-full lg:w-64 space-y-3">
-                                <EventBookingButton event={event} className="w-full" source="karaoke_event_card" />
-                            </div>
-                        </CardBody>
-                    </Card>
-                )
-            })}
-        </div>
+        <EventDateCards
+            events={events}
+            eyebrow="Karaoke Night"
+            bookingSource="karaoke_event_card"
+            imageAltSuffix="at The Anchor"
+            renderMeta={() => <p className="text-xs text-ink-muted">Free Entry</p>}
+            renderDetails={() => (
+                <p className="text-sm text-ink-muted">
+                    Grab the mic and show us what you've got. Check the event listing for host, timings and song details.
+                </p>
+            )}
+            emptyState={
+                <>
+                    <p className="text-lg font-semibold text-accent-text mb-2">Next karaoke dates coming soon</p>
+                    <p className="text-ink-muted">
+                        We're tuning the mics and scheduling the next night. Call 01753 682707 or check back shortly.
+                    </p>
+                </>
+            }
+        />
     )
 }
 

--- a/app/music-bingo/page.tsx
+++ b/app/music-bingo/page.tsx
@@ -1,8 +1,5 @@
-import Image from 'next/image'
-import { getEventHeroImage } from '@/lib/event-image'
 import { Metadata } from 'next'
 import {
-  Badge,
   Button,
   Container,
   Card,
@@ -18,21 +15,21 @@ import { PhoneButton } from '@/components/PhoneButton'
 import { CONTACT } from '@/lib/constants'
 import { FAQAccordionWithSchema } from '@/components/FAQAccordionWithSchema'
 import { EventSchema } from '@/components/seo/EventSchema'
-import { EventBookingButton } from '@/components/EventBookingButton'
 import { BookTableButton } from '@/components/BookTableButton'
+import { EventBookingButton } from '@/components/EventBookingButton'
+import { EventDateCards } from '@/components/features/EventDateCards'
 import { RegretReduction } from '@/components/psychology'
 import {
   getEventCategories,
   getUpcomingEventsByCategory,
   formatEventDate,
   formatEventTime,
-  formatDoorTime,
+  formatDoorClockTime,
   getLowestTicketTypePrice,
   hasMultipleTicketPrices,
   type Event,
   type EventCategory
 } from '@/lib/api'
-import { getEventWebsiteUrl } from '@/lib/event-url'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 import { DEFAULT_EVENT_IMAGE } from '@/lib/image-fallbacks'
@@ -187,86 +184,30 @@ function getEntryLabel(event: Event) {
 }
 
 function MusicBingoEventCards({ events }: { events: Event[] }) {
-  if (!events.length) {
-    return (
-      <Card accent>
-      <CardBody className="text-center">
-        <p className="mb-2 text-lg font-semibold text-accent-text">New Music Bingo dates are loading soon</p>
-        <p className="text-ink-muted">
-          We are lining up the next singalong sessions. Call 01753 682707 and we will share the next date as soon as booking opens.
-        </p>
-      </CardBody>
-      </Card>
-    )
-  }
-
   return (
-    <div className="space-y-6">
-      {events.map((event, index) => {
-        const doorTime = formatDoorTime(event.doorTime)
-        const startTime = formatEventTime(event.startDate)
-        const isDraft = (event.eventStatus || '').toLowerCase().includes('draft')
-        const isScheduled = (event.eventStatus || '').toLowerCase().includes('scheduled')
-        const isTentative = isDraft || (!isScheduled && new Date(event.startDate).getTime() > new Date().getTime() + 30 * 24 * 60 * 60 * 1000)
-        const eventUrl = getEventWebsiteUrl(event)
-        const imageSrc = getEventHeroImage(event)
-        const entryLabel = getEntryLabel(event)
-
-        return (
-          <Card key={event.id} hover accent className="overflow-hidden">
-            <div className="flex flex-wrap items-center justify-between gap-3 border-b border-line bg-surface-sunk px-5 py-4">
-              <div className="min-w-0">
-                <div className="mb-1 flex items-center gap-2">
-                  <p className="text-xs uppercase tracking-wide text-ink-muted">Music bingo night</p>
-                  {isTentative && (
-                    <Badge variant="outline">Tentative</Badge>
-                  )}
-                </div>
-                <Link href={eventUrl} className="block text-xl font-semibold text-ink-strong transition hover:text-accent-text">
-                  {event.name}
-                </Link>
-                <p className="text-sm text-ink-muted line-clamp-1">{formatEventDate(event.startDate)}</p>
-              </div>
-              <div className="text-right">
-                <p className="text-lg font-semibold text-ink-strong">{startTime}</p>
-                <p className="text-xs text-ink-muted">Doors {doorTime ?? '6:30pm'} - {entryLabel}</p>
-              </div>
-            </div>
-
-            <CardBody className="flex flex-col gap-6 lg:flex-row lg:items-stretch lg:gap-8">
-              {imageSrc && (
-                <Link href={eventUrl} className="w-full lg:w-48">
-                  <div className="relative aspect-square overflow-hidden rounded-xl shadow-sm">
-                    <Image
-                      src={imageSrc}
-                      alt={`${event.name} music bingo night at The Anchor`}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 1024px) 100vw, 192px"
-                      loading={index < 2 ? 'eager' : 'lazy'}
-                    />
-                  </div>
-                </Link>
-              )}
-
-              <div className="flex-1 space-y-4">
-                {event.description && (
-                  <p className="text-ink-muted leading-relaxed">{event.description}</p>
-                )}
-                <p className="text-sm text-ink-muted">
-                  Five rounds of song snippets, singalong prompts, and shout-outs. Grab your card, spot the track, and
-                  celebrate every line win.
-                </p>
-              </div>
-
-              <div className="w-full space-y-3 lg:w-64 lg:shrink-0">
-                <EventBookingButton event={event} className="w-full lg:px-6" source="music_bingo_event_card" />
-              </div>
-            </CardBody>
-          </Card>
-        )
-      })}
-    </div>
+    <EventDateCards
+      events={events}
+      eyebrow="Music bingo night"
+      bookingSource="music_bingo_event_card"
+      imageAltSuffix="music bingo night at The Anchor"
+      renderMeta={(event, doorTime) => (
+        <p className="text-xs text-ink-muted">Doors {doorTime ?? '6:30pm'} - {getEntryLabel(event)}</p>
+      )}
+      renderDetails={() => (
+        <p className="text-sm text-ink-muted">
+          Five rounds of song snippets, singalong prompts, and shout-outs. Grab your card, spot the track, and
+          celebrate every line win.
+        </p>
+      )}
+      emptyState={
+        <>
+          <p className="mb-2 text-lg font-semibold text-accent-text">New Music Bingo dates are loading soon</p>
+          <p className="text-ink-muted">
+            We are lining up the next singalong sessions. Call 01753 682707 and we will share the next date as soon as booking opens.
+          </p>
+        </>
+      }
+    />
   )
 }
 
@@ -275,7 +216,7 @@ export default async function MusicBingoPage() {
   const nextEvent = events[0]
   const nextEventDate = nextEvent ? formatEventDate(nextEvent.startDate) : 'Next date to be confirmed'
   const nextEventTime = nextEvent ? formatEventTime(nextEvent.startDate) : '8pm'
-  const doorTime = nextEvent ? formatDoorTime(nextEvent.doorTime) ?? '6:30pm' : '6:30pm'
+  const doorTime = nextEvent ? formatDoorClockTime(nextEvent.doorTime) ?? '6:30pm' : '6:30pm'
   const entryLabel = nextEvent ? getEntryLabel(nextEvent) : '£3 entry'
 
   const heroDescription = nextEvent

--- a/app/quiz-night/page.tsx
+++ b/app/quiz-night/page.tsx
@@ -1,5 +1,3 @@
-import Image from 'next/image'
-import { getEventHeroImage } from '@/lib/event-image'
 import { Metadata } from 'next'
 import {
   Badge,
@@ -22,17 +20,17 @@ import { FAQAccordionWithSchema } from '@/components/FAQAccordionWithSchema'
 import { EventSchema } from '@/components/seo/EventSchema'
 import { EventBookingButton } from '@/components/EventBookingButton'
 import { BookTableButton } from '@/components/BookTableButton'
+import { EventDateCards } from '@/components/features/EventDateCards'
 import { RegretReduction } from '@/components/psychology'
 import {
   getEventCategories,
   getUpcomingEventsByCategory,
   formatEventDate,
   formatEventTime,
-  formatDoorTime,
+  formatDoorClockTime,
   type Event,
   type EventCategory
 } from '@/lib/api'
-import { getEventWebsiteUrl } from '@/lib/event-url'
 import { DEFAULT_EVENT_IMAGE } from '@/lib/image-fallbacks'
 import { getTwitterMetadata } from '@/lib/twitter-metadata'
 import { JsonLd } from '@/components/JsonLd'
@@ -175,89 +173,38 @@ function PrizeCard({ title, reward, copy }: { title: string; reward: string; cop
 }
 
 function QuizNightEvents({ events }: { events: Event[] }) {
-  if (!events.length) {
-    return (
-      <Card accent>
-        <CardBody className="text-center">
+  return (
+    <EventDateCards
+      events={events}
+      eyebrow="Monthly quiz night"
+      bookingSource="quiz_night_event_card"
+      imageAltSuffix="quiz night at The Anchor"
+      renderMeta={(_event, doorTime) => (
+        <>
+          <p className="text-xs text-ink-muted">Doors {doorTime ?? '6:30pm'}</p>
+          <p className="text-xs text-ink-muted">£3 per player</p>
+        </>
+      )}
+      renderDetails={() => (
+        <>
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <Badge variant="success">£25 bar tab for winners</Badge>
+            <Badge variant="sand">Bottle of wine for second-from-last</Badge>
+          </div>
+          <p className="text-sm text-ink-muted">
+            £3 per player · Teams up to six · Solo players welcome (we’ll match you on arrival)
+          </p>
+        </>
+      )}
+      emptyState={
+        <>
           <p className="text-lg font-semibold text-accent-text mb-2">New quiz dates are loading soon</p>
           <p className="text-ink-muted">
             Our next quiz night is being finalised right now. Call 01753 682707 and we’ll let you know as soon as booking opens.
           </p>
-        </CardBody>
-      </Card>
-    )
-  }
-
-  return (
-    <div className="space-y-6">
-      {events.map((event, index) => {
-        const doorTime = formatDoorTime(event.doorTime)
-        const startTime = formatEventTime(event.startDate)
-        const isDraft = (event.eventStatus || '').toLowerCase().includes('draft')
-        const isScheduled = (event.eventStatus || '').toLowerCase().includes('scheduled')
-        const isTentative = isDraft || (!isScheduled && new Date(event.startDate).getTime() > new Date().getTime() + 30 * 24 * 60 * 60 * 1000)
-        const eventUrl = getEventWebsiteUrl(event)
-        const imageSrc = getEventHeroImage(event)
-
-        return (
-          <Card key={event.id} hover accent className="overflow-hidden">
-            <div className="border-b border-line bg-surface-sunk px-5 py-4 flex flex-wrap items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <p className="text-xs uppercase tracking-wide text-ink-muted">Monthly quiz night</p>
-                  {isTentative && (
-                    <Badge variant="outline">Tentative</Badge>
-                  )}
-                </div>
-                <Link href={eventUrl} className="block text-xl font-semibold text-ink-strong hover:text-accent-text transition">
-                  {event.name}
-                </Link>
-                <p className="text-sm text-ink-muted line-clamp-1">{formatEventDate(event.startDate)}</p>
-              </div>
-	              <div className="text-right">
-	                <p className="text-lg font-semibold text-ink-strong">{startTime}</p>
-	                <p className="text-xs text-ink-muted">Doors {doorTime ?? '6:30pm'}</p>
-	                <p className="text-xs text-ink-muted">£3 per player</p>
-	              </div>
-            </div>
-
-            <CardBody className="flex flex-col gap-6 lg:flex-row lg:items-stretch lg:gap-8">
-              {imageSrc && (
-                <Link href={eventUrl} className="w-full lg:w-48">
-                  <div className="relative aspect-square rounded-xl overflow-hidden shadow-sm">
-                    <Image
-                      src={imageSrc}
-                      alt={`${event.name} quiz night at The Anchor`}
-                      fill
-                      className="object-cover"
-                      sizes="(max-width: 1024px) 100vw, 192px"
-                      loading={index < 2 ? 'eager' : 'lazy'}
-                    />
-                  </div>
-                </Link>
-              )}
-
-              <div className="flex-1 space-y-4">
-                {event.description && (
-                  <p className="text-ink-muted leading-relaxed">{event.description}</p>
-                )}
-	                <div className="flex flex-wrap items-center gap-3 text-sm">
-	                  <Badge variant="success">£25 bar tab for winners</Badge>
-                  <Badge variant="sand">Bottle of wine for second-from-last</Badge>
-                </div>
-	                <p className="text-sm text-ink-muted">
-	                  £3 per player · Teams up to six · Solo players welcome (we’ll match you on arrival)
-	                </p>
-              </div>
-
-              <div className="w-full space-y-3 lg:w-64 lg:shrink-0">
-                <EventBookingButton event={event} className="w-full lg:px-6" source="quiz_night_event_card" />
-              </div>
-            </CardBody>
-          </Card>
-        )
-      })}
-    </div>
+        </>
+      }
+    />
   )
 }
 
@@ -266,7 +213,7 @@ export default async function QuizNightPage() {
   const nextEvent = events[0]
   const nextEventDate = nextEvent ? formatEventDate(nextEvent.startDate) : 'Next date to be confirmed'
   const nextEventTime = nextEvent ? formatEventTime(nextEvent.startDate) : '7:30 pm start'
-  const doorTime = nextEvent ? formatDoorTime(nextEvent.doorTime) ?? '6:30 pm' : '6:30 pm'
+  const doorTime = nextEvent ? formatDoorClockTime(nextEvent.doorTime) ?? '6:30 pm' : '6:30 pm'
 
 	  const heroDescription = nextEvent
 	    ? `Doors ${doorTime}. Quiz starts ${nextEventTime}. It’s £3 per player, build a team of up to six or arrive solo and we’ll match you.`

--- a/components/features/EventDateCards.tsx
+++ b/components/features/EventDateCards.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Badge, Card, CardBody } from '@/components/ui'
+import { EventBookingButton } from '@/components/EventBookingButton'
+import { getEventWebsiteUrl } from '@/lib/event-url'
+import { formatDoorClockTime, formatEventDate, formatEventTime, type Event } from '@/lib/api'
+
+// Shared "upcoming dates" list used by the event category pages (/music-bingo,
+// /cash-bingo, /quiz-night, /karaoke). These four pages each carried their own
+// copy of this markup, so a layout fix had to be made four times and drifted
+// between them. Anything genuinely per-page (eyebrow, meta lines, body copy)
+// comes in as a prop or render function.
+
+export interface EventDateCardsProps {
+  events: Event[]
+  /** Small uppercase label above the event name, e.g. "Music bingo night". */
+  eyebrow: string
+  /** GTM source passed to the booking button. */
+  bookingSource: string
+  /** Appended to the image alt text after the event name. */
+  imageAltSuffix: string
+  /** Right-hand meta block under the start time. `doorTime` is a bare clock time. */
+  renderMeta: (event: Event, doorTime: string | null) => ReactNode
+  /** Extra body content shown under the event description. */
+  renderDetails?: (event: Event) => ReactNode
+  /** Shown in place of the list when there are no upcoming events. */
+  emptyState: ReactNode
+}
+
+const TENTATIVE_AFTER_DAYS = 30
+
+function isTentativeEvent(event: Event): boolean {
+  const status = (event.eventStatus || '').toLowerCase()
+  if (status.includes('draft')) return true
+  if (status.includes('scheduled')) return false
+
+  const horizon = Date.now() + TENTATIVE_AFTER_DAYS * 24 * 60 * 60 * 1000
+  return new Date(event.startDate).getTime() > horizon
+}
+
+export function EventDateCards({
+  events,
+  eyebrow,
+  bookingSource,
+  imageAltSuffix,
+  renderMeta,
+  renderDetails,
+  emptyState
+}: EventDateCardsProps) {
+  if (!events.length) {
+    return (
+      <Card accent>
+        <CardBody className="text-center">{emptyState}</CardBody>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {events.map((event, index) => {
+        const doorTime = formatDoorClockTime(event.doorTime)
+        const eventUrl = getEventWebsiteUrl(event)
+        const imageSrc = event.heroImageUrl || event.image?.[0] || null
+
+        return (
+          <Card key={event.id} hover accent className="overflow-hidden">
+            {/* Stacks on phones. The meta block keeps its own alignment per
+                breakpoint: right-aligning it while it sits on its own full-width
+                row left it floating in the middle of the card. */}
+            <div className="flex flex-col gap-2 border-b border-line bg-surface-sunk px-5 py-4 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-3">
+              <div className="min-w-0">
+                <div className="mb-1 flex items-center gap-2">
+                  <p className="text-xs uppercase tracking-wide text-ink-muted">{eyebrow}</p>
+                  {isTentativeEvent(event) && <Badge variant="outline">Tentative</Badge>}
+                </div>
+                <Link href={eventUrl} className="block text-xl font-semibold text-ink-strong transition hover:text-accent-text">
+                  {event.name}
+                </Link>
+                <p className="text-sm text-ink-muted line-clamp-1">{formatEventDate(event.startDate)}</p>
+              </div>
+              <div className="shrink-0 text-left sm:text-right">
+                <p className="text-lg font-semibold text-ink-strong">{formatEventTime(event.startDate)}</p>
+                {renderMeta(event, doorTime)}
+              </div>
+            </div>
+
+            {/* Top-aligned, not centred: booking labels vary per event ("Book
+                seated or standing tickets" vs "Reserve a table, pay quiz entry on
+                arrival"), so a centred button starts higher when its label wraps
+                to an extra line and the column of CTAs reads as ragged. */}
+            <CardBody className="flex flex-col gap-6 lg:flex-row lg:items-start lg:gap-8">
+              {imageSrc && (
+                // lg:basis-48 is doing the real work, not lg:w-48. An aspect-ratio
+                // box inside a flex item sizes itself from the item's main size, so
+                // with the default `flex-basis: auto` the poster resolved to a
+                // content-based width of ~650px, squeezed the copy to nothing and
+                // pushed the booking button out of line with the other cards.
+                // A definite basis breaks that cycle.
+                <Link href={eventUrl} className="mx-auto w-full max-w-[16rem] lg:mx-0 lg:w-48 lg:max-w-none lg:shrink-0 lg:grow-0 lg:basis-48">
+                  <div className="relative aspect-square overflow-hidden rounded-xl shadow-sm">
+                    <Image
+                      src={imageSrc}
+                      alt={`${event.name} ${imageAltSuffix}`}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 1023px) 256px, 192px"
+                      loading={index < 2 ? 'eager' : 'lazy'}
+                    />
+                  </div>
+                </Link>
+              )}
+
+              <div className="min-w-0 flex-1 space-y-4">
+                {event.description && <p className="leading-relaxed text-ink-muted">{event.description}</p>}
+                {renderDetails?.(event)}
+              </div>
+
+              {/* 18rem, not 16rem: at 16rem the longest booking label needed a
+                  third line, making that one button 88px tall against everyone
+                  else's 60px. */}
+              <div className="w-full space-y-3 lg:w-72 lg:shrink-0 lg:grow-0 lg:basis-72">
+                <EventBookingButton event={event} className="w-full" source={bookingSource} />
+              </div>
+            </CardBody>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/layout/StickyCtas.tsx
+++ b/components/layout/StickyCtas.tsx
@@ -200,10 +200,14 @@ export function StickyCtas() {
           </Button>
         )}
 
+        {/* The label is screen-reader-only below sm, but the button kept its full
+            md padding, so on a 390px phone the four controls needed 418px and the
+            WhatsApp button was clipped off the right edge. */}
         <Button
           asChild
           variant="outline"
           size="md"
+          className="shrink-0 max-sm:h-12 max-sm:w-12 max-sm:px-0"
           icon={<Utensils className="h-5 w-5" aria-hidden />}
           tabIndex={showStickyCtas ? undefined : -1}
         >

--- a/components/ui/EventMetadata.tsx
+++ b/components/ui/EventMetadata.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils'
-import { formatEventDate, formatEventTime, formatDoorTime, formatPrice, type Event } from '@/lib/api'
+import { formatEventDate, formatEventTime, formatDoorClockTime, formatPrice, type Event } from '@/lib/api'
 
 interface EventMetadataProps {
   event: Partial<Event>
@@ -51,7 +51,7 @@ export function EventMetadata({
   }
 
   if (showDoorTime && event.doorTime) {
-    const doorTimeText = formatDoorTime(event.doorTime)
+    const doorTimeText = formatDoorClockTime(event.doorTime)
     if (doorTimeText) {
       metadata.push({
         icon: '',

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -599,11 +599,21 @@ export function getEventShortDescription(event: Event, maxLength: number = 150):
   return event.description
 }
 
-// Helper to format door time
-export function formatDoorTime(doorTimeString: string | null | undefined): string | null {
+// Helper to format door time as a bare clock time, e.g. "6:30pm".
+// Use this wherever the caller renders its own "Doors" label, otherwise the
+// label is printed twice ("Doors Doors: 6:30pm").
+export function formatDoorClockTime(doorTimeString: string | null | undefined): string | null {
   if (!doorTimeString) return null
 
-  return 'Doors: ' + formatEventLocalTime(doorTimeString)
+  return formatEventLocalTime(doorTimeString)
+}
+
+// Helper to format door time as a self-describing label, e.g. "Doors: 6:30pm".
+// Only for standalone use (badges, metadata rows with no label of their own).
+export function formatDoorTime(doorTimeString: string | null | undefined): string | null {
+  const clockTime = formatDoorClockTime(doorTimeString)
+
+  return clockTime ? `Doors: ${clockTime}` : null
 }
 
 // Helper to format event duration


### PR DESCRIPTION
Finishes the work stranded on `fix/event-page-card-layout`.

## What changed

Cash bingo, music bingo, quiz night and karaoke each carried their own copy of the same "upcoming dates" markup. A layout fix had to be made four times and drifted between them, which is exactly how the booking CTA column ended up different on three of them.

They now share `components/features/EventDateCards.tsx`. Anything genuinely per-page is passed in: eyebrow, GTM booking source, alt-text suffix, and render functions for the meta block and body detail.

Net effect: **254 insertions, 335 deletions.** Less code doing more consistent work.

## Why cherry-picked rather than rebased

`fix/event-page-card-layout` had eleven commits. Ten had already landed on main through #104 and #109; only `3d1138e0` held anything new. Rebasing would have replayed ten already-merged commits and generated conflicts for no gain, so I took the one commit that mattered.

## Two things reconciled

**37 width caps came back.** The branch was written before page width was standardised, so it reintroduced `max-w-2xl` through `max-w-5xl` across the four files. Stripped again under the same rules. The page-width audit from #105 caught them, which is the audit doing its job on work written before it existed.

**#111 is superseded, not lost.** The shared component already pins the booking column with `lg:shrink-0 lg:grow-0 lg:basis-72`, which keeps #111's intent and improves on it. Its narrower `lg:w-64` and `lg:px-6` are no longer needed.

## Testing done

- [x] Manual testing: on `/quiz-night`, all six booking buttons in the dates list render at an identical 288px from the same left edge, which was the original alignment problem. No console errors.
- [x] Automated tests: 1595 pass, typecheck clean, lint clean including the width audit, production build succeeds.

## Complexity score

M. One new shared component, four pages simplified.

## Breaking changes

None.

## Migration risk

Low. Presentational only, no data or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)